### PR TITLE
Fixed the removal of bloat files after vacuum full

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/jackc/pgx"
 	"github.com/jackc/pgx/pgtype"
@@ -81,7 +80,7 @@ func (database *DatabaseHandler) GetVirtualExpireIndexes(port uint64) (map[strin
 		if err := rows2.Scan(&xpath); err != nil {
 			return nil, nil, fmt.Errorf("unable to parse query output %v", err)
 		}
-		p2 := ReworkFileName(xpath)
+		p2 := xpath
 		c2[p2] = true
 		ylogger.Zero.Debug().Str("file", p2).Msg("added")
 	}
@@ -169,10 +168,4 @@ func connectToDatabase(port uint64, database string) (*pgx.Conn, error) {
 		}
 	}
 	return conn, nil
-}
-
-func ReworkFileName(str string) string {
-	p1 := strings.Split(str, "/")
-	p2 := strings.Join(p1, "_")
-	return p2
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -81,12 +81,7 @@ func (database *DatabaseHandler) GetVirtualExpireIndexes(port uint64) (map[strin
 		if err := rows2.Scan(&xpath); err != nil {
 			return nil, nil, fmt.Errorf("unable to parse query output %v", err)
 		}
-		p1 := strings.Split(xpath, "/")
-		p2 := p1[len(p1)-1]
-		p3 := strings.Split(p2, "_")
-		if len(p3) >= 4 {
-			p2 = fmt.Sprintf("%s_%s_%s_%s_", p3[0], p3[1], p3[2], p3[3])
-		}
+		p2 := ReworkFileName(xpath)
 		c2[p2] = true
 		ylogger.Zero.Debug().Str("file", p2).Msg("added")
 	}
@@ -174,4 +169,10 @@ func connectToDatabase(port uint64, database string) (*pgx.Conn, error) {
 		}
 	}
 	return conn, nil
+}
+
+func ReworkFileName(str string) string {
+	p1 := strings.Split(str, "/")
+	p2 := strings.Join(p1, "_")
+	return p2
 }

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -134,7 +134,7 @@ func (dh *BasicDeleteHandler) ListGarbageFiles(msg message.DeleteMessage) ([]str
 
 	filesToDelete := make([]string, 0)
 	for i := 0; i < len(objectMetas); i++ {
-		reworkedName := database.ReworkFileName(objectMetas[i].Path)
+		reworkedName := objectMetas[i].Path
 		ylogger.Zero.Debug().Str("reworked name", reworkedName).Msg("lookup chunk")
 
 		if vi[reworkedName] {

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -93,7 +93,7 @@ func (dh *BasicDeleteHandler) HandleDeleteGarbage(msg message.DeleteMessage) err
 func (dh *BasicDeleteHandler) HandleDeleteFile(msg message.DeleteMessage) error {
 	err := dh.StorageInterractor.DeleteObject(msg.Name)
 	if err != nil {
-		ylogger.Zero.Error().AnErr("err", err).Msg("failed to delete file")
+		ylogger.Zero.Error().AnErr("err", err).Msg("failed to delete file " + msg.Name)
 		return errors.Wrap(err, "failed to delete file")
 	}
 	return nil
@@ -134,7 +134,7 @@ func (dh *BasicDeleteHandler) ListGarbageFiles(msg message.DeleteMessage) ([]str
 
 	filesToDelete := make([]string, 0)
 	for i := 0; i < len(objectMetas); i++ {
-		reworkedName := ReworkFileName(objectMetas[i].Path)
+		reworkedName := database.ReworkFileName(objectMetas[i].Path)
 		ylogger.Zero.Debug().Str("reworked name", reworkedName).Msg("lookup chunk")
 
 		if vi[reworkedName] {
@@ -155,14 +155,4 @@ func (dh *BasicDeleteHandler) ListGarbageFiles(msg message.DeleteMessage) ([]str
 	ylogger.Zero.Info().Int("amount", len(filesToDelete)).Msg("files will be deleted")
 
 	return filesToDelete, nil
-}
-
-func ReworkFileName(str string) string {
-	p1 := strings.Split(str, "/")
-	p2 := p1[len(p1)-1]
-	p3 := strings.Split(p2, "_")
-	if len(p3) >= 4 {
-		p2 = fmt.Sprintf("%s_%s_%s_%s_", p3[0], p3[1], p3[2], p3[3])
-	}
-	return p2
 }

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/yezzey-gp/yproxy/config"
+	"github.com/yezzey-gp/yproxy/pkg/database"
 	"github.com/yezzey-gp/yproxy/pkg/message"
 	mock "github.com/yezzey-gp/yproxy/pkg/mock"
 	"github.com/yezzey-gp/yproxy/pkg/object"
@@ -46,7 +47,7 @@ func TestReworkingName(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		ans := proc.ReworkFileName(testCase.input)
+		ans := database.ReworkFileName(testCase.input)
 		assert.Equal(t, testCase.expected, ans)
 	}
 }

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -5,52 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/yezzey-gp/yproxy/config"
-	"github.com/yezzey-gp/yproxy/pkg/database"
 	"github.com/yezzey-gp/yproxy/pkg/message"
 	mock "github.com/yezzey-gp/yproxy/pkg/mock"
 	"github.com/yezzey-gp/yproxy/pkg/object"
 	"github.com/yezzey-gp/yproxy/pkg/proc"
 	"go.uber.org/mock/gomock"
 )
-
-func TestReworkingName(t *testing.T) {
-	type TestCase struct {
-		input    string
-		expected string
-	}
-
-	testCases := []TestCase{
-		{
-			input:    "/segments_005/seg1/basebackups_005/yezzey/1663_16530_a4c5ad8305b83f07200b020694c36563_17660_1__DY_1_xlog_19649822496",
-			expected: "1663_16530_a4c5ad8305b83f07200b020694c36563_17660_",
-		},
-		{
-			input:    "1663_16530_a4c5ad8305b83f07200b020694c36563_17660_1__DY_1_xlog_19649822496",
-			expected: "1663_16530_a4c5ad8305b83f07200b020694c36563_17660_",
-		},
-		{
-			input:    "seg1/basebackups_005/yezzey/1663_16530_a4c5ad8305b83f07200b020694c36563_17660_1__DY_1_xlog_19649822496",
-			expected: "1663_16530_a4c5ad8305b83f07200b020694c36563_17660_",
-		},
-		{
-			input:    "1663_16530_a4c5ad8305b83f07200b020694c36563",
-			expected: "1663_16530_a4c5ad8305b83f07200b020694c36563",
-		},
-		{
-			input:    "1663___a4c5ad8305b83f07200b020694c36563___",
-			expected: "1663___a4c5ad8305b83f07200b020694c36563_",
-		},
-		{
-			input:    "file",
-			expected: "file",
-		},
-	}
-
-	for _, testCase := range testCases {
-		ans := database.ReworkFileName(testCase.input)
-		assert.Equal(t, testCase.expected, ans)
-	}
-}
 
 func TestFilesToDeletion(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -248,7 +248,7 @@ func ProcessCopyExtended(msg message.CopyMessage, s storage.StorageInteractor, c
 		retryCount++
 		for i := 0; i < len(objectMetas); i++ {
 			path := strings.TrimPrefix(objectMetas[i].Path, instanceCnf.StorageCnf.StoragePrefix)
-			reworked := ReworkFileName(path)
+			reworked := path
 			if _, ok := vi[reworked]; !ok {
 				ylogger.Zero.Debug().Str("object path", objectMetas[i].Path).Msg("not in virtual index, skipping...")
 				continue


### PR DESCRIPTION
- yezzey_vacuum_garbage(true, false); now moves unnecessary bloat files to trash

- ReworkFileName now has the desired behavior
- Moved ReworkFileName so that there would be no cyclic import
- Added the output of the names of the files that were not deleted
- Removed the duplicate code (ReworkFileName)
