### PR TITLE
Add CopyMessageV2 & CopyComplete

### DIFF
--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -12,6 +12,13 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
+type KeyVersion byte
+
+const (
+	SingleKeyEncryption = KeyVersion(iota + 1)
+	KEKDEKEncryption
+)
+
 type Crypter interface {
 	Decrypt(reader io.ReadCloser) (io.Reader, error)
 	Encrypt(writer io.WriteCloser) (io.WriteCloser, error)

--- a/pkg/message/copy_complete.go
+++ b/pkg/message/copy_complete.go
@@ -1,0 +1,35 @@
+package message
+
+import (
+	"encoding/binary"
+)
+
+type CopyCompleteMessage struct {
+	KeyVersion byte
+}
+
+var _ ProtoMessage = &CopyCompleteMessage{}
+
+func NewCopyCompleteMessage(keyVersion byte) *CopyCompleteMessage {
+	return &CopyCompleteMessage{
+		KeyVersion: keyVersion,
+	}
+}
+
+func (c *CopyCompleteMessage) Encode() []byte {
+	bt := []byte{
+		byte(MessageTypeCopyComplete),
+		c.KeyVersion,
+		0,
+		0,
+	}
+	ln := len(bt) + 8
+
+	bs := make([]byte, 8)
+	binary.BigEndian.PutUint64(bs, uint64(ln))
+	return append(bs, bt...)
+}
+
+func (c *CopyCompleteMessage) Decode(body []byte) {
+	c.KeyVersion = body[1]
+}

--- a/pkg/message/copy_message_v2.go
+++ b/pkg/message/copy_message_v2.go
@@ -1,0 +1,116 @@
+package message
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/yezzey-gp/yproxy/pkg/ylogger"
+)
+
+const (
+	CopyEncrypt    = 0b1
+	CopyDecrypt    = 0b10
+	CopyUseKEK     = 0b100
+	CopyServerSide = 0b1000
+)
+
+type CopyMessageV2 struct {
+	Decrypt        bool
+	Encrypt        bool
+	Name           string
+	OldCfgPath     string
+	Port           uint64
+	Confirm        bool
+	KEKDecrypt     bool
+	ServerSideCopy bool
+}
+
+var _ ProtoMessage = &CopyMessageV2{}
+
+func NewCopyMessageV2(name, oldCfgPath string, encrypt, decrypt, confirm, kEKDecrypt, ssCopy bool, port uint64) *CopyMessageV2 {
+	return &CopyMessageV2{
+		Name:           name,
+		Encrypt:        encrypt,
+		Decrypt:        decrypt,
+		OldCfgPath:     oldCfgPath,
+		Port:           port,
+		Confirm:        confirm,
+		KEKDecrypt:     kEKDecrypt,
+		ServerSideCopy: ssCopy,
+	}
+}
+
+func (message *CopyMessageV2) Encode() []byte {
+	flags := byte(0)
+	if message.Decrypt {
+		flags |= CopyDecrypt
+	}
+	if message.Encrypt {
+		flags |= CopyEncrypt
+	}
+	if message.KEKDecrypt {
+		flags |= CopyUseKEK
+	}
+	if message.ServerSideCopy {
+		flags |= CopyServerSide
+	}
+
+	encodedMessage := []byte{
+		byte(MessageTypeCopyV2),
+		flags,
+		0,
+		0,
+	}
+
+	byteName := []byte(message.Name)
+	byteLen := make([]byte, 8)
+	binary.BigEndian.PutUint64(byteLen, uint64(len(byteName)))
+	encodedMessage = append(encodedMessage, byteLen...)
+	encodedMessage = append(encodedMessage, byteName...)
+
+	byteOldCfg := []byte(message.OldCfgPath)
+	binary.BigEndian.PutUint64(byteLen, uint64(len(byteOldCfg)))
+	encodedMessage = append(encodedMessage, byteLen...)
+	encodedMessage = append(encodedMessage, byteOldCfg...)
+
+	port := make([]byte, 8)
+	binary.BigEndian.PutUint64(port, uint64(message.Port))
+	encodedMessage = append(encodedMessage, port...)
+
+	if message.Confirm {
+		encodedMessage = append(encodedMessage, 1)
+	} else {
+		encodedMessage = append(encodedMessage, 0)
+	}
+
+	binary.BigEndian.PutUint64(byteLen, uint64(len(encodedMessage)+8))
+	fmt.Printf("send: %v\n", MessageType(encodedMessage[0]))
+	ylogger.Zero.Debug().Str("object-path", MessageType(encodedMessage[0]).String()).Msg("decrypt object")
+	return append(byteLen, encodedMessage...)
+}
+
+func (encodedMessage *CopyMessageV2) Decode(data []byte) {
+	if data[1]&CopyDecrypt != 0 {
+		encodedMessage.Decrypt = true
+	}
+	if data[1]&CopyEncrypt != 0 {
+		encodedMessage.Encrypt = true
+	}
+	if data[1]&CopyUseKEK != 0 {
+		encodedMessage.KEKDecrypt = true
+	}
+	if data[1]&CopyServerSide != 0 {
+		encodedMessage.ServerSideCopy = true
+	}
+
+	nameLen := binary.BigEndian.Uint64(data[4:12])
+	encodedMessage.Name = string(data[12 : 12+nameLen])
+	oldConfLen := binary.BigEndian.Uint64(data[12+nameLen : 12+nameLen+8])
+	encodedMessage.OldCfgPath = string(data[12+nameLen+8 : 12+nameLen+8+oldConfLen])
+	encodedMessage.Port = binary.BigEndian.Uint64(data[12+nameLen+8+oldConfLen : 12+nameLen+8+oldConfLen+8])
+
+	ind := 12 + nameLen + 8 + oldConfLen + 8
+	if data[ind] == 1 {
+		encodedMessage.Confirm = true
+	}
+}

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -30,6 +30,7 @@ const (
 	MessageTypePutComplete
 	MessageTypeUntrashify
 	MessageTypeCopyV2
+	MessageTypeCopyComplete
 
 	DecryptMessage   = RequestEncryption(1)
 	NoDecryptMessage = RequestEncryption(0)

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -29,6 +29,7 @@ const (
 	MessageTypePutV3
 	MessageTypePutComplete
 	MessageTypeUntrashify
+	MessageTypeCopyV2
 
 	DecryptMessage   = RequestEncryption(1)
 	NoDecryptMessage = RequestEncryption(0)


### PR DESCRIPTION
In CopyV2, key encryption key usage can be specified, as well as demand for server-side copy(both options currently unsupported). Also, CopyComplete message is sent in responce to CopyMessageV2, containing key version information