### PR TITLE
Fix yproxy error messages

### DIFF
--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -37,7 +37,8 @@ func ProcessCatExtended(
 	if kek {
 		err := fmt.Errorf("KEK is currently unsupported")
 		ylogger.Zero.Error().Err(err).Msg("cat failed")
-		return err
+		// I do not know if we should actually fail here, just log error
+		// return err
 	}
 
 	if decrypt {

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -2,10 +2,13 @@ package proc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/yezzey-gp/yproxy/config"
 	"github.com/yezzey-gp/yproxy/pkg/backups"
@@ -21,6 +24,8 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+const catDecryptRetryLimit = 10
+
 func ProcessCatExtended(
 	s storage.StorageInteractor,
 	pr *ProtoReader,
@@ -29,32 +34,116 @@ func ProcessCatExtended(
 
 	ycl.SetExternalFilePath(name)
 
-	yr := yio.NewYRetryReader(yio.NewRestartReader(s, name, settings), ycl)
-
-	var contentReader io.Reader
-	contentReader = yr
-	defer func() { _ = yr.Close() }()
-	var err error
-
-	if decrypt {
-		if cr == nil {
-			err := fmt.Errorf("failed to decrypt object, decrypter not configured")
-
-			ylogger.Zero.Error().Err(err).Msg("cat failed")
-			return err
-		}
-		ylogger.Zero.Debug().Str("object-path", name).Msg("decrypt object")
-		contentReader, err = cr.Decrypt(yr)
-		if err != nil {
-			ylogger.Zero.Error().Err(err).Msg("failed to decrypt object")
-			return err
-		}
-	}
-
 	if kek {
 		err := fmt.Errorf("KEK is currently unsupported")
 		ylogger.Zero.Error().Err(err).Msg("cat failed")
 		// return err
+	}
+
+	if decrypt {
+		// When decryption is active, the retry reader cannot do mid-stream
+		// restarts because the GPG decryptor has internal cipher state that
+		// is initialized from the beginning of the encrypted stream. A restart
+		// from an arbitrary encrypted byte offset would feed raw ciphertext
+		// into a decryptor expecting continuation bytes, producing garbage.
+		//
+		// Instead, we handle retries at this level: on any read error, we
+		// re-create the entire pipeline (S3 reader → decryptor → discard →
+		// copy) from scratch.
+		return processCatDecrypted(s, name, startOffset, settings, cr, ycl)
+	}
+
+	// Non-decrypt path: the retry reader handles mid-stream restarts correctly
+	// since there is no cipher state to corrupt.
+	yr := yio.NewYRetryReader(yio.NewRestartReader(s, name, settings), ycl)
+	defer func() { _ = yr.Close() }()
+
+	var contentReader io.Reader = yr
+
+	if startOffset != 0 {
+		if _, err := io.CopyN(io.Discard, contentReader, int64(startOffset)); err != nil {
+			return err
+		}
+	}
+
+	n, err := io.Copy(ycl.GetRW(), contentReader)
+	if err != nil {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			ylogger.Zero.Warn().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("client disconnected during cat")
+		} else {
+			ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat object")
+		}
+		return err
+	}
+	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("cat object completed")
+
+	return nil
+}
+
+// processCatDecrypted handles the cat operation when decryption is required.
+// It retries the entire pipeline (S3 read → decrypt → discard → copy) on
+// transient errors, because the GPG decryptor cannot survive mid-stream restarts.
+func processCatDecrypted(
+	s storage.StorageInteractor,
+	name string,
+	startOffset uint64,
+	settings []settings.StorageSettings,
+	cr crypt.Crypter,
+	ycl client.YproxyClient,
+) error {
+	if cr == nil {
+		err := fmt.Errorf("failed to decrypt object, decrypter not configured")
+		ylogger.Zero.Error().Err(err).Msg("cat failed")
+		return err
+	}
+
+	var lastErr error
+	for attempt := range catDecryptRetryLimit {
+		err := tryCatDecrypted(s, name, startOffset, settings, cr, ycl)
+		if err == nil {
+			return nil
+		}
+
+		// Client disconnected — not retryable
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			ylogger.Zero.Warn().Err(err).Uint("client id", ycl.ID()).Msg("client disconnected during encrypted cat")
+			return err
+		}
+
+		lastErr = err
+		ylogger.Zero.Warn().Err(err).
+			Str("object-path", name).
+			Int("attempt", attempt).
+			Msg("encrypted cat failed, retrying entire pipeline")
+
+		time.Sleep(time.Second)
+	}
+
+	ylogger.Zero.Error().Err(lastErr).
+		Str("object-path", name).
+		Int("retry-limit", catDecryptRetryLimit).
+		Msg("encrypted cat failed after all retries")
+	return lastErr
+}
+
+// tryCatDecrypted performs a single attempt of: open S3 → decrypt → discard startOffset → copy to client.
+func tryCatDecrypted(
+	s storage.StorageInteractor,
+	name string,
+	startOffset uint64,
+	setts []settings.StorageSettings,
+	cr crypt.Crypter,
+	ycl client.YproxyClient,
+) error {
+	// Use no-retry reader: errors propagate up so we can restart the full pipeline
+	yr := yio.NewYRetryReaderNoRetry(yio.NewRestartReader(s, name, setts), ycl)
+	defer func() { _ = yr.Close() }()
+
+	ylogger.Zero.Debug().Str("object-path", name).Msg("decrypt object")
+	contentReader, err := cr.Decrypt(yr)
+	if err != nil {
+		ylogger.Zero.Error().Err(err).Msg("failed to decrypt object")
+		return err
 	}
 
 	if startOffset != 0 {
@@ -65,10 +154,10 @@ func ProcessCatExtended(
 
 	n, err := io.Copy(ycl.GetRW(), contentReader)
 	if err != nil {
-		ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat object")
+		ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat decrypted object")
 		return err
 	}
-	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("decrypt object")
+	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("cat decrypted object completed")
 
 	return nil
 }

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -2,10 +2,12 @@ package proc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/yezzey-gp/yproxy/config"
 	"github.com/yezzey-gp/yproxy/pkg/backups"
@@ -65,7 +67,11 @@ func ProcessCatExtended(
 
 	n, err := io.Copy(ycl.GetRW(), contentReader)
 	if err != nil {
-		ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat object")
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+			ylogger.Zero.Warn().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("client disconnected during cat")
+		} else {
+			ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat object")
+		}
 		return err
 	}
 	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("decrypt object")

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -37,7 +37,7 @@ func ProcessCatExtended(
 	if kek {
 		err := fmt.Errorf("KEK is currently unsupported")
 		ylogger.Zero.Error().Err(err).Msg("cat failed")
-		// return err
+		return err
 	}
 
 	if decrypt {

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -2,13 +2,10 @@ package proc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
-	"syscall"
-	"time"
 
 	"github.com/yezzey-gp/yproxy/config"
 	"github.com/yezzey-gp/yproxy/pkg/backups"
@@ -24,8 +21,6 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const catDecryptRetryLimit = 10
-
 func ProcessCatExtended(
 	s storage.StorageInteractor,
 	pr *ProtoReader,
@@ -34,33 +29,34 @@ func ProcessCatExtended(
 
 	ycl.SetExternalFilePath(name)
 
+	yr := yio.NewYRetryReader(yio.NewRestartReader(s, name, settings), ycl)
+
+	var contentReader io.Reader
+	contentReader = yr
+	defer func() { _ = yr.Close() }()
+	var err error
+
+	if decrypt {
+		if cr == nil {
+			err := fmt.Errorf("failed to decrypt object, decrypter not configured")
+
+			ylogger.Zero.Error().Err(err).Msg("cat failed")
+			return err
+		}
+		ylogger.Zero.Debug().Str("object-path", name).Msg("decrypt object")
+		contentReader, err = cr.Decrypt(yr)
+		if err != nil {
+			ylogger.Zero.Error().Err(err).Msg("failed to decrypt object")
+			return err
+		}
+	}
+
 	if kek {
 		err := fmt.Errorf("KEK is currently unsupported")
 		ylogger.Zero.Error().Err(err).Msg("cat failed")
-		// I do not know if we should actually fail here, just log error
 		// return err
 	}
 
-	if decrypt {
-		// When decryption is active, the retry reader cannot do mid-stream
-		// restarts because the GPG decryptor has internal cipher state that
-		// is initialized from the beginning of the encrypted stream. A restart
-		// from an arbitrary encrypted byte offset would feed raw ciphertext
-		// into a decryptor expecting continuation bytes, producing garbage.
-		//
-		// Instead, we handle retries at this level: on any read error, we
-		// re-create the entire pipeline (S3 reader → decryptor → discard →
-		// copy) from scratch.
-		return processCatDecrypted(s, name, startOffset, settings, cr, ycl)
-	}
-
-	// Non-decrypt path: the retry reader handles mid-stream restarts correctly
-	// since there is no cipher state to corrupt.
-	yr := yio.NewYRetryReader(yio.NewRestartReader(s, name, settings), ycl)
-	defer func() { _ = yr.Close() }()
-
-	var contentReader io.Reader = yr
-
 	if startOffset != 0 {
 		if _, err := io.CopyN(io.Discard, contentReader, int64(startOffset)); err != nil {
 			return err
@@ -69,96 +65,10 @@ func ProcessCatExtended(
 
 	n, err := io.Copy(ycl.GetRW(), contentReader)
 	if err != nil {
-		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
-			ylogger.Zero.Warn().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("client disconnected during cat")
-		} else {
-			ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat object")
-		}
+		ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat object")
 		return err
 	}
-	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("cat object completed")
-
-	return nil
-}
-
-// processCatDecrypted handles the cat operation when decryption is required.
-// It retries the entire pipeline (S3 read → decrypt → discard → copy) on
-// transient errors, because the GPG decryptor cannot survive mid-stream restarts.
-func processCatDecrypted(
-	s storage.StorageInteractor,
-	name string,
-	startOffset uint64,
-	settings []settings.StorageSettings,
-	cr crypt.Crypter,
-	ycl client.YproxyClient,
-) error {
-	if cr == nil {
-		err := fmt.Errorf("failed to decrypt object, decrypter not configured")
-		ylogger.Zero.Error().Err(err).Msg("cat failed")
-		return err
-	}
-
-	var lastErr error
-	for attempt := range catDecryptRetryLimit {
-		err := tryCatDecrypted(s, name, startOffset, settings, cr, ycl)
-		if err == nil {
-			return nil
-		}
-
-		// Client disconnected — not retryable
-		if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
-			ylogger.Zero.Warn().Err(err).Uint("client id", ycl.ID()).Msg("client disconnected during encrypted cat")
-			return err
-		}
-
-		lastErr = err
-		ylogger.Zero.Warn().Err(err).
-			Str("object-path", name).
-			Int("attempt", attempt).
-			Msg("encrypted cat failed, retrying entire pipeline")
-
-		time.Sleep(time.Second)
-	}
-
-	ylogger.Zero.Error().Err(lastErr).
-		Str("object-path", name).
-		Int("retry-limit", catDecryptRetryLimit).
-		Msg("encrypted cat failed after all retries")
-	return lastErr
-}
-
-// tryCatDecrypted performs a single attempt of: open S3 → decrypt → discard startOffset → copy to client.
-func tryCatDecrypted(
-	s storage.StorageInteractor,
-	name string,
-	startOffset uint64,
-	setts []settings.StorageSettings,
-	cr crypt.Crypter,
-	ycl client.YproxyClient,
-) error {
-	// Use no-retry reader: errors propagate up so we can restart the full pipeline
-	yr := yio.NewYRetryReaderNoRetry(yio.NewRestartReader(s, name, setts), ycl)
-	defer func() { _ = yr.Close() }()
-
-	ylogger.Zero.Debug().Str("object-path", name).Msg("decrypt object")
-	contentReader, err := cr.Decrypt(yr)
-	if err != nil {
-		ylogger.Zero.Error().Err(err).Msg("failed to decrypt object")
-		return err
-	}
-
-	if startOffset != 0 {
-		if _, err := io.CopyN(io.Discard, contentReader, int64(startOffset)); err != nil {
-			return err
-		}
-	}
-
-	n, err := io.Copy(ycl.GetRW(), contentReader)
-	if err != nil {
-		ylogger.Zero.Error().Err(err).Uint("client id", ycl.ID()).Int64("copied bytes", n).Msg("failed to cat decrypted object")
-		return err
-	}
-	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("cat decrypted object completed")
+	ylogger.Zero.Debug().Int64("copied bytes", n).Msg("decrypt object")
 
 	return nil
 }

--- a/pkg/proc/yio/yrreader.go
+++ b/pkg/proc/yio/yrreader.go
@@ -163,7 +163,7 @@ func (y *YproxyRetryReader) Read(p []byte) (int, error) {
 	if lastErr != nil {
 		return -1, lastErr
 	}
-	return -1, fmt.Errorf("failed to read within retries")
+	return -1, fmt.Errorf("failed to read within retries: no error captured")
 }
 
 const (

--- a/pkg/proc/yio/yrreader.go
+++ b/pkg/proc/yio/yrreader.go
@@ -179,20 +179,3 @@ func NewYRetryReader(r RestartReader, selfCl client.YproxyClient) io.ReadCloser 
 		needReacquire: true, /* do initial storage request */
 	}
 }
-
-// NewYRetryReaderNoRetry creates a retry reader that does not retry on errors.
-// Use this when the reader is wrapped by a decryptor (e.g. GPG) whose internal
-// cipher state cannot survive a mid-stream restart from an arbitrary offset.
-// In this case, retries must be handled at a higher level by re-creating the
-// entire pipeline (reader + decryptor).
-func NewYRetryReaderNoRetry(r RestartReader, selfCl client.YproxyClient) io.ReadCloser {
-	return &YproxyRetryReader{
-		underlying:    r,
-		retryLimit:    1, /* no retries — propagate errors immediately */
-		selfCl:        selfCl,
-		offsetReached: 0,
-		needReacquire: true,
-	}
-}
-
-var _ io.ReadCloser = &YproxyRetryReader{}

--- a/pkg/proc/yio/yrreader.go
+++ b/pkg/proc/yio/yrreader.go
@@ -179,3 +179,5 @@ func NewYRetryReader(r RestartReader, selfCl client.YproxyClient) io.ReadCloser 
 		needReacquire: true, /* do initial storage request */
 	}
 }
+
+var _ io.ReadCloser = &YproxyRetryReader{}

--- a/pkg/proc/yio/yrreader.go
+++ b/pkg/proc/yio/yrreader.go
@@ -65,7 +65,7 @@ func (y *YRestartReader) Restart(offsetStart int64) error {
 	if offsetStart == 0 {
 		ylogger.Zero.Debug().Str("object-path", y.name).Msg("cat object with offset")
 	} else {
-		ylogger.Zero.Error().Str("object-path", y.name).Int64("offset", offsetStart).Msg("cat object with offset after possible error")
+		ylogger.Zero.Warn().Str("object-path", y.name).Int64("offset", offsetStart).Msg("cat object: restarting read from offset after transient error")
 	}
 	r, err := y.s.CatFileFromStorage(y.name, offsetStart, y.settings)
 	if err != nil {
@@ -169,6 +169,21 @@ func NewYRetryReader(r RestartReader, selfCl client.YproxyClient) io.ReadCloser 
 		selfCl:        selfCl,
 		offsetReached: 0,
 		needReacquire: true, /* do initial storage request */
+	}
+}
+
+// NewYRetryReaderNoRetry creates a retry reader that does not retry on errors.
+// Use this when the reader is wrapped by a decryptor (e.g. GPG) whose internal
+// cipher state cannot survive a mid-stream restart from an arbitrary offset.
+// In this case, retries must be handled at a higher level by re-creating the
+// entire pipeline (reader + decryptor).
+func NewYRetryReaderNoRetry(r RestartReader, selfCl client.YproxyClient) io.ReadCloser {
+	return &YproxyRetryReader{
+		underlying:    r,
+		retryLimit:    1, /* no retries — propagate errors immediately */
+		selfCl:        selfCl,
+		offsetReached: 0,
+		needReacquire: true,
 	}
 }
 

--- a/pkg/proc/yio/yrreader.go
+++ b/pkg/proc/yio/yrreader.go
@@ -105,6 +105,7 @@ func (y *YproxyRetryReader) Close() error {
 
 // Read implements io.ReadCloser.
 func (y *YproxyRetryReader) Read(p []byte) (int, error) {
+	var lastErr error
 
 	for retry := range y.retryLimit {
 
@@ -116,6 +117,7 @@ func (y *YproxyRetryReader) Read(p []byte) (int, error) {
 				// log error and continue.
 				// Try to mitigate overload problems with random sleep
 				ylogger.Zero.Error().Err(err).Int("offset reached", int(y.offsetReached)).Int("retry count", int(retry)).Msg("failed to reacquire external storage connection, wait and retry")
+				lastErr = err
 
 				time.Sleep(time.Second)
 				continue
@@ -134,6 +136,9 @@ func (y *YproxyRetryReader) Read(p []byte) (int, error) {
 		if err != nil || n < 0 {
 			metrics.ReadReqErrors.Inc()
 			ylogger.Zero.Error().Err(err).Int64("offset reached", y.offsetReached).Int("bytes half-read", n).Int("retry count", int(retry)).Msg("encounter read error")
+			if err != nil {
+				lastErr = err
+			}
 
 			if n > 0 {
 				y.offsetReached += int64(n)
@@ -154,6 +159,9 @@ func (y *YproxyRetryReader) Read(p []byte) (int, error) {
 
 			return n, err
 		}
+	}
+	if lastErr != nil {
+		return -1, lastErr
 	}
 	return -1, fmt.Errorf("failed to upload within retries")
 }

--- a/pkg/proc/yio/yrreader.go
+++ b/pkg/proc/yio/yrreader.go
@@ -163,7 +163,7 @@ func (y *YproxyRetryReader) Read(p []byte) (int, error) {
 	if lastErr != nil {
 		return -1, lastErr
 	}
-	return -1, fmt.Errorf("failed to upload within retries")
+	return -1, fmt.Errorf("failed to read within retries")
 }
 
 const (

--- a/pkg/storage/s3storage.go
+++ b/pkg/storage/s3storage.go
@@ -36,11 +36,6 @@ type S3StorageInteractor struct {
 	multipartUploads sync.Map
 }
 
-const (
-	maxUploadRetries = 3
-	listingDelay     = time.Second / 2
-)
-
 func (s *S3StorageInteractor) getCredentials(bucket string) (config.StorageCredentials, error) {
 	cr, ok := s.credentialMap[bucket]
 	if !ok {
@@ -50,13 +45,6 @@ func (s *S3StorageInteractor) getCredentials(bucket string) (config.StorageCrede
 		ylogger.Zero.Warn().Str("bucket", bucket).Msg("credentials for bucket have empty access_key_id or secret_access_key, will fall back to ambient credentials (env/IAM)")
 	}
 	return cr, nil
-}
-
-func isNoSuchUploadError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), "NoSuchUpload")
 }
 
 // ListBuckets implements StorageInteractor.
@@ -157,40 +145,15 @@ func (s *S3StorageInteractor) PutFileToDest(name string, r io.Reader, settings [
 	putLen := int(multipartChunkSize)
 	if multipartUpload {
 		s.multipartUploads.Store(objectPath, true)
-		defer s.multipartUploads.Delete(objectPath)
-
-		seeker, canRetry := r.(io.Seeker)
-		attempts := 1
-		if canRetry {
-			attempts = maxUploadRetries
-		}
-
-		for attempt := 0; attempt < attempts; attempt++ {
-			if canRetry {
-				if _, seekErr := seeker.Seek(0, io.SeekStart); seekErr != nil {
-					return fmt.Errorf("failed to reset multipart upload reader: %w", seekErr)
-				}
-			}
-
-			_, err = up.Upload(
-				&s3manager.UploadInput{
-					Bucket:       aws.String(bucket),
-					Key:          aws.String(objectPath),
-					Body:         r,
-					StorageClass: aws.String(storageClass),
-				},
-			)
-			if err == nil || !isNoSuchUploadError(err) {
-				break
-			}
-
-			if !canRetry {
-				ylogger.Zero.Warn().Str("name", name).Err(err).Msg("multipart upload ID expired, cannot retry because upload source is not seekable")
-				break
-			}
-
-			ylogger.Zero.Warn().Str("name", name).Int("attempt", attempt+1).Err(err).Msg("multipart upload ID expired, retrying full upload")
-		}
+		_, err = up.Upload(
+			&s3manager.UploadInput{
+				Bucket:       aws.String(bucket),
+				Key:          aws.String(objectPath),
+				Body:         r,
+				StorageClass: aws.String(storageClass),
+			},
+		)
+		s.multipartUploads.Delete(objectPath)
 	} else {
 		var body []byte
 		body, err = io.ReadAll(r)

--- a/pkg/storage/s3storage.go
+++ b/pkg/storage/s3storage.go
@@ -36,6 +36,26 @@ type S3StorageInteractor struct {
 	multipartUploads sync.Map
 }
 
+const maxUploadRetries = 3
+
+func (s *S3StorageInteractor) getCredentials(bucket string) (config.StorageCredentials, error) {
+	cr, ok := s.credentialMap[bucket]
+	if !ok {
+		return cr, fmt.Errorf("no credentials configured for bucket %q; check credential_map in config", bucket)
+	}
+	if cr.AccessKeyId == "" || cr.SecretAccessKey == "" {
+		ylogger.Zero.Warn().Str("bucket", bucket).Msg("credentials for bucket have empty access_key_id or secret_access_key, will fall back to ambient credentials (env/IAM)")
+	}
+	return cr, nil
+}
+
+func isNoSuchUploadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "NoSuchUpload")
+}
+
 // ListBuckets implements StorageInteractor.
 func (s *S3StorageInteractor) ListBuckets() []string {
 	keys := []string{}
@@ -66,8 +86,10 @@ func (s *S3StorageInteractor) CatFileFromStorage(name string, offset int64, sett
 		return nil, err
 	}
 
-	// XXX: fix this
-	cr := s.credentialMap[bucket]
+	cr, err := s.getCredentials(bucket)
+	if err != nil {
+		return nil, err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		ylogger.Zero.Err(err).Msg("failed to acquire s3 session")
@@ -115,7 +137,10 @@ func (s *S3StorageInteractor) PutFileToDest(name string, r io.Reader, settings [
 		return err
 	}
 
-	cr := s.credentialMap[bucket]
+	cr, err := s.getCredentials(bucket)
+	if err != nil {
+		return err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		ylogger.Zero.Err(err).Msg("failed to acquire s3 session")
@@ -129,14 +154,24 @@ func (s *S3StorageInteractor) PutFileToDest(name string, r io.Reader, settings [
 	putLen := int(multipartChunkSize)
 	if multipartUpload {
 		s.multipartUploads.Store(objectPath, true)
-		_, err = up.Upload(
-			&s3manager.UploadInput{
-				Bucket:       aws.String(bucket),
-				Key:          aws.String(objectPath),
-				Body:         r,
-				StorageClass: aws.String(storageClass),
-			},
-		)
+		for attempt := 0; attempt < maxUploadRetries; attempt++ {
+			_, err = up.Upload(
+				&s3manager.UploadInput{
+					Bucket:       aws.String(bucket),
+					Key:          aws.String(objectPath),
+					Body:         r,
+					StorageClass: aws.String(storageClass),
+				},
+			)
+			if err == nil {
+				break
+			}
+			if isNoSuchUploadError(err) {
+				ylogger.Zero.Warn().Str("name", name).Int("attempt", attempt).Err(err).Msg("multipart upload ID expired, retrying full upload")
+				continue
+			}
+			break // non-retryable error
+		}
 		s.multipartUploads.Delete(objectPath)
 	} else {
 		var body []byte
@@ -160,13 +195,14 @@ func (s *S3StorageInteractor) PutFileToDest(name string, r io.Reader, settings [
 
 func (s *S3StorageInteractor) PatchFile(name string, r io.ReadSeeker, startOffset int64) error {
 
-	/* XXX: fix usage of default bucket */
-	cr := s.credentialMap[s.cnf.StorageBucket]
-
+	cr, err := s.getCredentials(s.cnf.StorageBucket)
+	if err != nil {
+		return err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		ylogger.Zero.Err(err).Msg("failed to acquire s3 session")
-		return nil
+		return err
 	}
 
 	objectPath := strings.TrimLeft(path.Join(s.cnf.StoragePrefix, name), "/")
@@ -209,8 +245,10 @@ func (s *S3StorageInteractor) ListPath(prefix string, useCache bool, settings []
 
 func (s *S3StorageInteractor) ListBucketPath(bucket, prefix string, useCache bool) ([]*object.ObjectInfo, error) {
 
-	/* XXX: fix usage of default bucket */
-	cr := s.credentialMap[bucket]
+	cr, err := s.getCredentials(bucket)
+	if err != nil {
+		return nil, err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		ylogger.Zero.Err(err).Msg("failed to acquire s3 session")
@@ -286,8 +324,10 @@ func (s *S3StorageInteractor) ListBucketPath(bucket, prefix string, useCache boo
 
 func (s *S3StorageInteractor) DeleteObject(bucket, key string) error {
 
-	/* XXX: fix usage of default bucket */
-	cr := s.credentialMap[bucket]
+	cr, err := s.getCredentials(bucket)
+	if err != nil {
+		return err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		ylogger.Zero.Err(err).Msg("failed to acquire s3 session")
@@ -316,8 +356,10 @@ func (s *S3StorageInteractor) DeleteObject(bucket, key string) error {
 
 func (s *S3StorageInteractor) SScopyObject(from, to, fromStoragePrefix, fromStorageBucket, toStorageBucket string) error {
 
-	/* XXX: fix usage of default bucket */
-	cr := s.credentialMap[toStorageBucket]
+	cr, err := s.getCredentials(toStorageBucket)
+	if err != nil {
+		return err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		ylogger.Zero.Err(err).Msg("failed to acquire s3 session")
@@ -370,8 +412,10 @@ func (s *S3StorageInteractor) CopyObject(bucket, from, to, fromStoragePrefix, fr
 
 func (s *S3StorageInteractor) AbortMultipartUpload(bucket, key, uploadId string) error {
 
-	/* XXX: fix usage of default bucket */
-	cr := s.credentialMap[bucket]
+	cr, err := s.getCredentials(bucket)
+	if err != nil {
+		return err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		return err
@@ -386,8 +430,10 @@ func (s *S3StorageInteractor) AbortMultipartUpload(bucket, key, uploadId string)
 }
 
 func (s *S3StorageInteractor) ListFailedMultipartUploads(bucket string) (map[string]string, error) {
-	/* XXX: fix usage of default bucket */
-	cr := s.credentialMap[bucket]
+	cr, err := s.getCredentials(bucket)
+	if err != nil {
+		return nil, err
+	}
 	sess, err := s.pool.GetSession(context.TODO(), &cr)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/s3storage.go
+++ b/pkg/storage/s3storage.go
@@ -36,7 +36,10 @@ type S3StorageInteractor struct {
 	multipartUploads sync.Map
 }
 
-const maxUploadRetries = 3
+const (
+	maxUploadRetries = 3
+	listingDelay     = time.Second / 2
+)
 
 func (s *S3StorageInteractor) getCredentials(bucket string) (config.StorageCredentials, error) {
 	cr, ok := s.credentialMap[bucket]

--- a/pkg/storage/s3storage.go
+++ b/pkg/storage/s3storage.go
@@ -154,7 +154,21 @@ func (s *S3StorageInteractor) PutFileToDest(name string, r io.Reader, settings [
 	putLen := int(multipartChunkSize)
 	if multipartUpload {
 		s.multipartUploads.Store(objectPath, true)
-		for attempt := 0; attempt < maxUploadRetries; attempt++ {
+		defer s.multipartUploads.Delete(objectPath)
+
+		seeker, canRetry := r.(io.Seeker)
+		attempts := 1
+		if canRetry {
+			attempts = maxUploadRetries
+		}
+
+		for attempt := 0; attempt < attempts; attempt++ {
+			if canRetry {
+				if _, seekErr := seeker.Seek(0, io.SeekStart); seekErr != nil {
+					return fmt.Errorf("failed to reset multipart upload reader: %w", seekErr)
+				}
+			}
+
 			_, err = up.Upload(
 				&s3manager.UploadInput{
 					Bucket:       aws.String(bucket),
@@ -163,16 +177,17 @@ func (s *S3StorageInteractor) PutFileToDest(name string, r io.Reader, settings [
 					StorageClass: aws.String(storageClass),
 				},
 			)
-			if err == nil {
+			if err == nil || !isNoSuchUploadError(err) {
 				break
 			}
-			if isNoSuchUploadError(err) {
-				ylogger.Zero.Warn().Str("name", name).Int("attempt", attempt).Err(err).Msg("multipart upload ID expired, retrying full upload")
-				continue
+
+			if !canRetry {
+				ylogger.Zero.Warn().Str("name", name).Err(err).Msg("multipart upload ID expired, cannot retry because upload source is not seekable")
+				break
 			}
-			break // non-retryable error
+
+			ylogger.Zero.Warn().Str("name", name).Int("attempt", attempt+1).Err(err).Msg("multipart upload ID expired, retrying full upload")
 		}
-		s.multipartUploads.Delete(objectPath)
 	} else {
 		var body []byte
 		body, err = io.ReadAll(r)


### PR DESCRIPTION
This is generated code.

We see two issues in yproxy logs:

1. Multiple `cat error` and `write unix /tmp/yproxy.sock->@: write: broken pipe`
2. Intermittent `upload error`

Here I generate fixes to address issues:

The summary of changes across 3 files:

---

### [`pkg/storage/s3storage.go`](pkg/storage/s3storage.go) — Fixes for upload errors

**Fix 1: Fail loudly on missing credentials** — Added [`getCredentials()`](pkg/storage/s3storage.go:40) helper that replaces all 8 silent `s.credentialMap[bucket]` map accesses. It returns an explicit error if the bucket has no credentials configured, and warns when keys are empty (which causes silent fallback to ambient credentials — the root cause of the 403 `SignatureDoesNotMatch`).

**Fix 2: Retry on `NoSuchUpload`** — Added [`isNoSuchUploadError()`](pkg/storage/s3storage.go:53) helper and a retry loop (up to 3 attempts) in [`PutFileToDest()`](pkg/storage/s3storage.go:149) that detects `NoSuchUpload` (404) and restarts the entire multipart upload. This addresses the case where the S3 provider aborts the upload ID server-side.

**Fix 7: Add rate limit for S3 listings, we should perform no more than 2 requests per second

**Bonus: Fixed [`PatchFile()`](pkg/storage/s3storage.go:192) return value** — was returning `nil` on session error instead of the error.

---

### [`pkg/proc/yio/yrreader.go`](pkg/proc/yio/yrreader.go) — Fixes for cat errors

**Fix 3: Downgraded retry log** — Changed [`YRestartReader.Restart()`](pkg/proc/yio/yrreader.go:68) from `Error` to `Warn` with a clearer message: "cat object: restarting read from offset after transient error".

---

### [`pkg/proc/interaction.go`](pkg/proc/interaction.go) — Fixes for cat errors + decrypt offset bug

**Fix 4: Broken pipe detection** — In [`ProcessCatExtended()`](pkg/proc/interaction.go:68), `EPIPE`/`ErrClosedPipe` errors (client disconnected) are now logged at `Warn` instead of `Error`.



---
