### PR TITLE
Protect recently created chunks from yezzey vacuum garbage deletion

### DIFF
--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -344,6 +344,8 @@ func (dh *BasicGarbageMgr) HandleDeleteFile(msg message.DeleteMessage) error {
 }
 
 func (dh *BasicGarbageMgr) ListGarbageFiles(bucket string, msg message.DeleteMessage) ([]*object.ObjectInfo, error) {
+	procStartTime := time.Now()
+
 	// Get first backup lsn
 	var firstBackupLSN uint64
 	var err error
@@ -381,6 +383,18 @@ func (dh *BasicGarbageMgr) ListGarbageFiles(bucket string, msg message.DeleteMes
 		ylogger.Zero.Debug().Str("reworked name", reworkedName).Msg("lookup chunk")
 
 		if vi[reworkedName] {
+			continue
+		}
+
+		// Never delete a file that was created/modified at or after the
+		// moment this vacuum procedure started listing storage. Such a file
+		// could not have been accounted for by the virtual/expire index
+		// snapshot taken above.
+		if objectMetas[i].LastMod.After(procStartTime) {
+			ylogger.Zero.Debug().Str("file", objectMetas[i].Path).
+				Time("last modified", objectMetas[i].LastMod).
+				Time("proc start", procStartTime).
+				Msg("file was created after vacuum procedure started, skipping")
 			continue
 		}
 

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,54 @@ func TestFilesToDeletion(t *testing.T) {
 	assert.Equal(t, 2, len(list))
 	assert.Equal(t, "1663_16530_deleted-before-backup_18002_", list[0].Path)
 	assert.Equal(t, "some_trash", list[1].Path)
+}
+
+func TestFilesToDeletionSkipsRecentlyCreatedFiles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	msg := message.DeleteMessage{
+		Name:    "path",
+		Port:    6000,
+		Segnum:  0,
+		Confirm: false,
+	}
+
+	oldFile := &object.ObjectInfo{
+		Path:    "1663_16530_old-garbage_18002_",
+		LastMod: time.Now().Add(-time.Hour),
+	}
+	recentFile := &object.ObjectInfo{
+		Path:    "1663_16530_recently-created_18002_",
+		LastMod: time.Now().Add(time.Hour), // created after vacuum started
+	}
+
+	filesInStorage := []*object.ObjectInfo{oldFile, recentFile}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().ListBucketPath("", msg.Name, true).Return(filesInStorage, nil)
+
+	backup := mock.NewMockBackupInterractor(ctrl)
+	backup.EXPECT().GetFirstLSN(msg.Segnum).Return(uint64(1337), nil)
+
+	// Neither file is present in virtual or expire index, so both would
+	// normally be considered garbage.
+	vi := map[string]bool{}
+	ei := map[string]uint64{}
+	database := mock.NewMockDatabaseInterractor(ctrl)
+	database.EXPECT().GetVirtualExpireIndexes(msg.Port).Return(vi, ei, nil)
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+		DbInterractor:      database,
+		BackupInterractor:  backup,
+		Cnf:                &config.Vacuum{CheckBackup: true},
+	}
+
+	list, err := handler.ListGarbageFiles("", msg)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, oldFile.Path, list[0].Path)
 }
 
 func TestTrashPathConversion(t *testing.T) {

--- a/pkg/storage/filestorage.go
+++ b/pkg/storage/filestorage.go
@@ -79,7 +79,7 @@ func (s *FileStorageInteractor) ListPath(prefix string, _ bool, _ []settings.Sto
 		if !ok {
 			return err
 		}
-		data = append(data, &object.ObjectInfo{Path: "/" + cPath, Size: fileinfo.Size()})
+		data = append(data, &object.ObjectInfo{Path: "/" + cPath, Size: fileinfo.Size(), LastMod: fileinfo.ModTime()})
 		return nil
 	})
 	return data, err


### PR DESCRIPTION
Adds a safety check that excludes any storage object modified at/after the moment the vacuum scan started, preventing race conditions where a chunk created during a vacuum run could be mistakenly deleted. Also fixes a bug where the file-storage backend never populated LastMod, making the new protection inert for that backend.