### PR TITLE
Add protection_seconds config to prevent deletion of recently created files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 yproxy - a service for efficient transfer data external storages.
 
+## vacuum / garbage collection configuration
+
+The `vacuum` section of the yproxy configuration file controls the
+behaviour of garbage collection performed during
+`yezzey_vacuum_garbage` / `yezzey_vacuum_garbage_relation` and the `yezzey_collect_obsolete` /
+`yezzey_delete_obsolete` procedures.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `check_backup` | bool | `true` | Whether to take the first backup LSN into account when deciding if a file is safe to delete. |
+| `file_chunk_per_sec` | int | `1000` | Rate limit (files/sec) applied while listing and deleting objects. |
+| `trash_retention_days` | int | `7` | Number of days a file stays in `/trash` before being permanently removed. |
+| `trash_delete_workers` | int | `1` | Number of parallel workers used to delete files from `/trash`. |
+| `protection_window` | duration | `24h` | Minimum age a file must have, based on its storage `LastMod` timestamp, before it is eligible for garbage deletion. Accepts a duration string, e.g. `"1h"`, `"30m"`, `"24h"`. Set to `"0s"` to disable this extra protection window. |
+
+Regardless of the `protection_window` value, yproxy **always**
+unconditionally skips any file whose `LastMod` timestamp is at or
+after the moment the vacuum/garbage-collection procedure started
+listing storage. Such files could not have been accounted for by the
+virtual/expire index snapshot taken during that run, so deleting them
+could destroy data written concurrently with the vacuum (e.g. by an
+`INSERT`/`UPDATE`/`ALTER` running while `yezzey_vacuum_garbage_relation`
+is in progress). The `protection_window` parameter only extends this
+protection window *backwards* in time, additionally skipping files that
+are younger than the configured duration even if they were created
+before the procedure started.
 
 ## debugging
 

--- a/config/instance.go
+++ b/config/instance.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v2"
@@ -83,6 +84,7 @@ const (
 	DefaultFileChunkPerSec    = 1000
 	DefaultTrashRetentionDays = 7
 	DefaultTrashDeleteWorkers = 1
+	DefaultProtectionWindow   = 24 * time.Hour
 )
 
 func EmbedDefaults(cfgInstance *Instance) {
@@ -116,7 +118,6 @@ func EmbedDefaults(cfgInstance *Instance) {
 	if cfgInstance.MetricsPort == 0 {
 		cfgInstance.MetricsPort = DefaultMetricsPort
 	}
-
 	if cfgInstance.VacuumCnf.FileChunkPerSec == 0 {
 		cfgInstance.VacuumCnf.FileChunkPerSec = DefaultFileChunkPerSec
 	}
@@ -125,6 +126,9 @@ func EmbedDefaults(cfgInstance *Instance) {
 	}
 	if cfgInstance.VacuumCnf.TrashDeleteWorkers == 0 {
 		cfgInstance.VacuumCnf.TrashDeleteWorkers = DefaultTrashDeleteWorkers
+	}
+	if cfgInstance.VacuumCnf.ProtectionWindow == 0 {
+		cfgInstance.VacuumCnf.ProtectionWindow = DefaultProtectionWindow
 	}
 	cfgInstance.YezzeyRestoreParanoid = false
 }

--- a/config/vacuum.go
+++ b/config/vacuum.go
@@ -1,8 +1,11 @@
 package config
 
+import "time"
+
 type Vacuum struct {
-	CheckBackup        bool `json:"check_backup" toml:"check_backup" yaml:"check_backup"`
-	FileChunkPerSec    int  `json:"file_chunk_per_sec" toml:"file_chunk_per_sec" yaml:"file_chunk_per_sec"`
-	TrashRetentionDays int  `json:"trash_retention_days" toml:"trash_retention_days" yaml:"trash_retention_days"`
-	TrashDeleteWorkers int  `json:"trash_delete_workers" toml:"trash_delete_workers" yaml:"trash_delete_workers"`
+	CheckBackup        bool          `json:"check_backup" toml:"check_backup" yaml:"check_backup"`
+	FileChunkPerSec    int           `json:"file_chunk_per_sec" toml:"file_chunk_per_sec" yaml:"file_chunk_per_sec"`
+	TrashRetentionDays int           `json:"trash_retention_days" toml:"trash_retention_days" yaml:"trash_retention_days"`
+	TrashDeleteWorkers int           `json:"trash_delete_workers" toml:"trash_delete_workers" yaml:"trash_delete_workers"`
+	ProtectionWindow   time.Duration `json:"protection_window" toml:"protection_window" yaml:"protection_window"`
 }

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -386,15 +386,16 @@ func (dh *BasicGarbageMgr) ListGarbageFiles(bucket string, msg message.DeleteMes
 			continue
 		}
 
-		// Never delete a file that was created/modified at or after the
-		// moment this vacuum procedure started listing storage. Such a file
-		// could not have been accounted for by the virtual/expire index
-		// snapshot taken above.
-		if objectMetas[i].LastMod.After(procStartTime) {
+		protectionWindow := dh.Cnf.ProtectionWindow
+		if protectionWindow < 0 {
+			protectionWindow = 0
+		}
+		if objectMetas[i].LastMod.After(procStartTime.Add(-protectionWindow)) {
 			ylogger.Zero.Debug().Str("file", objectMetas[i].Path).
 				Time("last modified", objectMetas[i].LastMod).
 				Time("proc start", procStartTime).
-				Msg("file was created after vacuum procedure started, skipping")
+				Dur("protection window", protectionWindow).
+				Msg("file is within the protection window, skipping")
 			continue
 		}
 

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -115,6 +115,111 @@ func TestFilesToDeletionSkipsRecentlyCreatedFiles(t *testing.T) {
 	assert.Equal(t, oldFile.Path, list[0].Path)
 }
 
+func TestFilesToDeletionRespectsProtectionSecondsWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	msg := message.DeleteMessage{
+		Name:    "path",
+		Port:    6000,
+		Segnum:  0,
+		Confirm: false,
+	}
+
+	oldFile := &object.ObjectInfo{
+		Path:    "1663_16530_old-garbage_18002_",
+		LastMod: time.Now().Add(-2 * time.Hour),
+	}
+	// Created before the vacuum procedure started, but within the
+	// configured protection window, so it must be skipped.
+	withinWindowFile := &object.ObjectInfo{
+		Path:    "1663_16530_within-window_18002_",
+		LastMod: time.Now().Add(-10 * time.Minute),
+	}
+
+	filesInStorage := []*object.ObjectInfo{oldFile, withinWindowFile}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().ListBucketPath("", msg.Name, true).Return(filesInStorage, nil)
+
+	backup := mock.NewMockBackupInterractor(ctrl)
+	backup.EXPECT().GetFirstLSN(msg.Segnum).Return(uint64(1337), nil)
+
+	// Neither file is present in virtual or expire index, so both would
+	// normally be considered garbage.
+	vi := map[string]bool{}
+	ei := map[string]uint64{}
+	database := mock.NewMockDatabaseInterractor(ctrl)
+	database.EXPECT().GetVirtualExpireIndexes(msg.Port).Return(vi, ei, nil)
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+		DbInterractor:      database,
+		BackupInterractor:  backup,
+		Cnf: &config.Vacuum{
+			CheckBackup:      true,
+			ProtectionWindow: time.Hour,
+		},
+	}
+
+	list, err := handler.ListGarbageFiles("", msg)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, oldFile.Path, list[0].Path)
+}
+
+func TestFilesToDeletionClampsNegativeProtectionSeconds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	msg := message.DeleteMessage{
+		Name:    "path",
+		Port:    6000,
+		Segnum:  0,
+		Confirm: false,
+	}
+
+	oldFile := &object.ObjectInfo{
+		Path:    "1663_16530_old-garbage_18002_",
+		LastMod: time.Now().Add(-2 * time.Hour),
+	}
+	// Created after the vacuum procedure started. Even with a negative
+	// (misconfigured) ProtectionSeconds, this file must still be
+	// unconditionally protected.
+	recentFile := &object.ObjectInfo{
+		Path:    "1663_16530_recently-created_18002_",
+		LastMod: time.Now().Add(time.Hour),
+	}
+
+	filesInStorage := []*object.ObjectInfo{oldFile, recentFile}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().ListBucketPath("", msg.Name, true).Return(filesInStorage, nil)
+
+	backup := mock.NewMockBackupInterractor(ctrl)
+	backup.EXPECT().GetFirstLSN(msg.Segnum).Return(uint64(1337), nil)
+
+	vi := map[string]bool{}
+	ei := map[string]uint64{}
+	database := mock.NewMockDatabaseInterractor(ctrl)
+	database.EXPECT().GetVirtualExpireIndexes(msg.Port).Return(vi, ei, nil)
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+		DbInterractor:      database,
+		BackupInterractor:  backup,
+		Cnf: &config.Vacuum{
+			CheckBackup:      true,
+			ProtectionWindow: -time.Hour, // misconfigured, must be clamped to 0
+		},
+	}
+
+	list, err := handler.ListGarbageFiles("", msg)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, oldFile.Path, list[0].Path)
+}
+
 func TestTrashPathConversion(t *testing.T) {
 
 	type tt struct {


### PR DESCRIPTION
The `protection_seconds` parameter has been added to the `vacuum` section of the yproxy. config. Files whose `LastMod` timestamp falls within the protection window (from `procStartTime - protectionWindow` to `procStartTime`) are skipped during garbage collection.

P.S. Continued https://github.com/open-gpdb/yproxy/pull/175