### PR TITLE
Preserve explicit zero config values when applying defaults

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -262,3 +262,8 @@ setport
 mws
 ydt
 zerolog
+nbackup
+ncheck
+nmetrics
+nprotection
+npsql

--- a/config/instance.go
+++ b/config/instance.go
@@ -3,13 +3,11 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/BurntSushi/toml"
+	"gopkg.in/yaml.v2"
 	"log"
 	"os"
 	"strings"
-	"time"
-
-	"github.com/BurntSushi/toml"
-	"gopkg.in/yaml.v2"
 )
 
 type Instance struct {
@@ -55,7 +53,7 @@ func InstanceConfig() *Instance {
 }
 
 func initInstanceConfig(file *os.File, cfgInstance *Instance) error {
-	cfgInstance.VacuumCnf.CheckBackup = true
+	cfgInstance.VacuumCnf = *BuildVacuum()
 	if strings.HasSuffix(file.Name(), ".toml") {
 		_, err := toml.NewDecoder(file).Decode(cfgInstance)
 		return err
@@ -80,11 +78,6 @@ const (
 
 	/* 1 GB per  second */
 	DefaultStorageRateLimit = 1024 * 1024 * 1024
-
-	DefaultFileChunkPerSec    = 1000
-	DefaultTrashRetentionDays = 7
-	DefaultTrashDeleteWorkers = 1
-	DefaultProtectionWindow   = 24 * time.Hour
 )
 
 func EmbedDefaults(cfgInstance *Instance) {
@@ -117,18 +110,6 @@ func EmbedDefaults(cfgInstance *Instance) {
 	}
 	if cfgInstance.MetricsPort == 0 {
 		cfgInstance.MetricsPort = DefaultMetricsPort
-	}
-	if cfgInstance.VacuumCnf.FileChunkPerSec == 0 {
-		cfgInstance.VacuumCnf.FileChunkPerSec = DefaultFileChunkPerSec
-	}
-	if cfgInstance.VacuumCnf.TrashRetentionDays == 0 {
-		cfgInstance.VacuumCnf.TrashRetentionDays = DefaultTrashRetentionDays
-	}
-	if cfgInstance.VacuumCnf.TrashDeleteWorkers == 0 {
-		cfgInstance.VacuumCnf.TrashDeleteWorkers = DefaultTrashDeleteWorkers
-	}
-	if cfgInstance.VacuumCnf.ProtectionWindow == 0 {
-		cfgInstance.VacuumCnf.ProtectionWindow = DefaultProtectionWindow
 	}
 	cfgInstance.YezzeyRestoreParanoid = false
 }

--- a/config/instance.go
+++ b/config/instance.go
@@ -125,10 +125,10 @@ func initInstanceConfig(file *os.File, cfgInstance *Instance) error {
 		return err
 	}
 	if strings.HasSuffix(file.Name(), ".yaml") {
-		return yaml.NewDecoder(file).Decode(&cfgInstance)
+		return yaml.NewDecoder(file).Decode(cfgInstance)
 	}
 	if strings.HasSuffix(file.Name(), ".json") {
-		return json.NewDecoder(file).Decode(&cfgInstance)
+		return json.NewDecoder(file).Decode(cfgInstance)
 	}
 	return fmt.Errorf("unknown config format type: %s. Use .toml, .yaml or .json suffix in filename", file.Name())
 }

--- a/config/instance.go
+++ b/config/instance.go
@@ -52,8 +52,74 @@ func InstanceConfig() *Instance {
 	return &cfgInstance
 }
 
+type InstanceOption func(*Instance)
+
+func WithStorageCnf(storage Storage) InstanceOption {
+	return func(i *Instance) {
+		i.StorageCnf = storage
+	}
+}
+
+func WithBackupStorageCnf(storage Storage) InstanceOption {
+	return func(i *Instance) {
+		i.BackupStorageCnf = storage
+	}
+}
+
+func WithVacuumCnf(vacuum Vacuum) InstanceOption {
+	return func(i *Instance) {
+		i.VacuumCnf = vacuum
+	}
+}
+
+func WithStatPort(statPort int) InstanceOption {
+	return func(i *Instance) {
+		i.StatPort = statPort
+	}
+}
+
+func WithPsqlPort(psqlPort int) InstanceOption {
+	return func(i *Instance) {
+		i.PsqlPort = psqlPort
+	}
+}
+
+func WithMetricsPort(metricsPort int) InstanceOption {
+	return func(i *Instance) {
+		i.MetricsPort = metricsPort
+	}
+}
+
+const (
+	DefaultStatPort    = 7432
+	DefaultPsqlPort    = 8432
+	DefaultMetricsPort = 2112
+)
+
+func BuildInstance(opts ...InstanceOption) *Instance {
+	i := &Instance{}
+
+	ApplyInstanceOptions(i,
+		WithStorageCnf(*BuildStorage()),
+		WithBackupStorageCnf(*BuildBackupStorage()),
+		WithVacuumCnf(*BuildVacuum()),
+		WithStatPort(DefaultStatPort),
+		WithPsqlPort(DefaultPsqlPort),
+		WithMetricsPort(DefaultMetricsPort),
+	)
+	ApplyInstanceOptions(i, opts...)
+
+	return i
+}
+
+func ApplyInstanceOptions(i *Instance, opts ...InstanceOption) {
+	for _, opt := range opts {
+		opt(i)
+	}
+}
+
 func initInstanceConfig(file *os.File, cfgInstance *Instance) error {
-	cfgInstance.VacuumCnf = *BuildVacuum()
+	*cfgInstance = *BuildInstance()
 	if strings.HasSuffix(file.Name(), ".toml") {
 		_, err := toml.NewDecoder(file).Decode(cfgInstance)
 		return err
@@ -67,56 +133,7 @@ func initInstanceConfig(file *os.File, cfgInstance *Instance) error {
 	return fmt.Errorf("unknown config format type: %s. Use .toml, .yaml or .json suffix in filename", file.Name())
 }
 
-const (
-	DefaultStorageConcurrency     = 100
-	DefaultCopyStorageConcurrency = 200
-	DefaultStatPort               = 7432
-	DefaultPsqlPort               = 8432
-	DefaultMetricsPort            = 2112
-
-	DefaultEndpointSourceScheme = "https"
-
-	/* 1 GB per  second */
-	DefaultStorageRateLimit = 1024 * 1024 * 1024
-)
-
-func EmbedDefaults(cfgInstance *Instance) {
-	if cfgInstance.StorageCnf.StorageType == "" {
-		cfgInstance.StorageCnf.StorageType = "s3"
-	}
-	if cfgInstance.StorageCnf.StorageConcurrency == 0 {
-		cfgInstance.StorageCnf.StorageConcurrency = DefaultStorageConcurrency
-	}
-	if cfgInstance.StorageCnf.CopyStorageConcurrency == 0 {
-		cfgInstance.StorageCnf.CopyStorageConcurrency = DefaultCopyStorageConcurrency
-	}
-	if cfgInstance.BackupStorageCnf.StorageType == "" {
-		cfgInstance.BackupStorageCnf.StorageType = "s3"
-	}
-	if cfgInstance.BackupStorageCnf.StorageConcurrency == 0 {
-		cfgInstance.BackupStorageCnf.StorageConcurrency = DefaultStorageConcurrency
-	}
-	if cfgInstance.StatPort == 0 {
-		cfgInstance.StatPort = DefaultStatPort
-	}
-	if cfgInstance.PsqlPort == 0 {
-		cfgInstance.PsqlPort = DefaultPsqlPort
-	}
-	if cfgInstance.StorageCnf.EndpointSourceScheme == "" {
-		cfgInstance.StorageCnf.EndpointSourceScheme = DefaultEndpointSourceScheme
-	}
-	if cfgInstance.StorageCnf.StorageRateLimit == 0 {
-		cfgInstance.StorageCnf.StorageRateLimit = DefaultStorageRateLimit
-	}
-	if cfgInstance.MetricsPort == 0 {
-		cfgInstance.MetricsPort = DefaultMetricsPort
-	}
-	cfgInstance.YezzeyRestoreParanoid = false
-}
-
-var (
-	bootstrapCfgPath = ""
-)
+var bootstrapCfgPath = ""
 
 func ReloadInstanceConfig() (*Instance, error) {
 	if err := LoadInstanceConfig(bootstrapCfgPath); err != nil {
@@ -136,7 +153,6 @@ func LoadInstanceConfig(cfgPath string) (err error) {
 	}
 
 	cfgInstance.ReadSystemdSocketPath()
-	EmbedDefaults(&cfgInstance)
 
 	configBytes, err := json.MarshalIndent(cfgInstance, "", "  ")
 	if err != nil {

--- a/config/instance_test.go
+++ b/config/instance_test.go
@@ -18,13 +18,64 @@ func writeTestConfig(t *testing.T, filename string, content string) string {
 	return path
 }
 
-func TestReadInstanceConfigUsesDefaultVacuumWhenUnset(t *testing.T) {
+func TestReadInstanceConfigUsesDefaultsWhenUnset(t *testing.T) {
 	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "socket_path: /tmp/yproxy.sock\n"))
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
 
+	assertDefaultStorage(t, cfg.StorageCnf)
+	assertDefaultBackupStorage(t, cfg.BackupStorageCnf)
 	assertDefaultVacuum(t, cfg.VacuumCnf)
+	if cfg.StatPort != DefaultStatPort {
+		t.Fatalf("expected default stat port %v, got %v", DefaultStatPort, cfg.StatPort)
+	}
+	if cfg.PsqlPort != DefaultPsqlPort {
+		t.Fatalf("expected default psql port %v, got %v", DefaultPsqlPort, cfg.PsqlPort)
+	}
+	if cfg.MetricsPort != DefaultMetricsPort {
+		t.Fatalf("expected default metrics port %v, got %v", DefaultMetricsPort, cfg.MetricsPort)
+	}
+}
+
+func TestReadInstanceConfigPreservesExplicitZeroPortsYAML(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "stat_port: 0\npsql_port: 0\nmetrics_port: 0\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.StatPort != 0 {
+		t.Fatalf("expected explicit zero stat port, got %v", cfg.StatPort)
+	}
+	if cfg.PsqlPort != 0 {
+		t.Fatalf("expected explicit zero psql port, got %v", cfg.PsqlPort)
+	}
+	if cfg.MetricsPort != 0 {
+		t.Fatalf("expected explicit zero metrics port, got %v", cfg.MetricsPort)
+	}
+}
+
+func TestReadInstanceConfigPreservesExplicitZeroStorageYAML(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "storage:\n  storage_concurrency: 0\n  copy_storage_concurrency: 0\n  storage_rate_limit: 0\n  storage_endpoint_source_scheme: \"\"\nbackup_storage:\n  storage_concurrency: 0\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.StorageCnf.StorageConcurrency != 0 {
+		t.Fatalf("expected explicit zero storage concurrency, got %v", cfg.StorageCnf.StorageConcurrency)
+	}
+	if cfg.StorageCnf.CopyStorageConcurrency != 0 {
+		t.Fatalf("expected explicit zero copy storage concurrency, got %v", cfg.StorageCnf.CopyStorageConcurrency)
+	}
+	if cfg.StorageCnf.StorageRateLimit != 0 {
+		t.Fatalf("expected explicit zero storage rate limit, got %v", cfg.StorageCnf.StorageRateLimit)
+	}
+	if cfg.StorageCnf.EndpointSourceScheme != "" {
+		t.Fatalf("expected explicit empty endpoint source scheme, got %q", cfg.StorageCnf.EndpointSourceScheme)
+	}
+	if cfg.BackupStorageCnf.StorageConcurrency != 0 {
+		t.Fatalf("expected explicit zero backup storage concurrency, got %v", cfg.BackupStorageCnf.StorageConcurrency)
+	}
 }
 
 func TestReadInstanceConfigPreservesExplicitZeroProtectionWindowYAML(t *testing.T) {
@@ -82,6 +133,46 @@ func TestReadInstanceConfigPreservesExplicitFalseCheckBackupTOML(t *testing.T) {
 	}
 	if cfg.VacuumCnf.ProtectionWindow != 0 {
 		t.Fatalf("expected explicit zero protection window, got %v", cfg.VacuumCnf.ProtectionWindow)
+	}
+}
+
+func assertDefaultStorage(t *testing.T, storage Storage) {
+	t.Helper()
+
+	if storage.StorageType != "s3" {
+		t.Fatalf("expected default storage type %q, got %q", "s3", storage.StorageType)
+	}
+	if storage.StorageConcurrency != DefaultStorageConcurrency {
+		t.Fatalf("expected default storage concurrency %v, got %v", DefaultStorageConcurrency, storage.StorageConcurrency)
+	}
+	if storage.CopyStorageConcurrency != DefaultCopyStorageConcurrency {
+		t.Fatalf("expected default copy storage concurrency %v, got %v", DefaultCopyStorageConcurrency, storage.CopyStorageConcurrency)
+	}
+	if storage.StorageRateLimit != DefaultStorageRateLimit {
+		t.Fatalf("expected default storage rate limit %v, got %v", DefaultStorageRateLimit, storage.StorageRateLimit)
+	}
+	if storage.EndpointSourceScheme != DefaultEndpointSourceScheme {
+		t.Fatalf("expected default endpoint source scheme %q, got %q", DefaultEndpointSourceScheme, storage.EndpointSourceScheme)
+	}
+}
+
+func assertDefaultBackupStorage(t *testing.T, storage Storage) {
+	t.Helper()
+
+	if storage.StorageType != "s3" {
+		t.Fatalf("expected default backup storage type %q, got %q", "s3", storage.StorageType)
+	}
+	if storage.StorageConcurrency != DefaultStorageConcurrency {
+		t.Fatalf("expected default backup storage concurrency %v, got %v", DefaultStorageConcurrency, storage.StorageConcurrency)
+	}
+	if storage.CopyStorageConcurrency != 0 {
+		t.Fatalf("expected default backup copy storage concurrency %v, got %v", 0, storage.CopyStorageConcurrency)
+	}
+	if storage.StorageRateLimit != 0 {
+		t.Fatalf("expected default backup storage rate limit %v, got %v", 0, storage.StorageRateLimit)
+	}
+	if storage.EndpointSourceScheme != "" {
+		t.Fatalf("expected default backup endpoint source scheme %q, got %q", "", storage.EndpointSourceScheme)
 	}
 }
 

--- a/config/instance_test.go
+++ b/config/instance_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTestConfig(t *testing.T, filename string, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), filename)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	return path
+}
+
+func TestReadInstanceConfigUsesDefaultVacuumWhenUnset(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "socket_path: /tmp/yproxy.sock\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	assertDefaultVacuum(t, cfg.VacuumCnf)
+}
+
+func TestReadInstanceConfigPreservesExplicitZeroProtectionWindowYAML(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "vacuum:\n  protection_window: 0s\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.VacuumCnf.ProtectionWindow != 0 {
+		t.Fatalf("expected explicit zero protection window, got %v", cfg.VacuumCnf.ProtectionWindow)
+	}
+}
+
+func TestReadInstanceConfigPreservesExplicitProtectionWindowYAML(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "vacuum:\n  protection_window: 1h\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.VacuumCnf.ProtectionWindow != time.Hour {
+		t.Fatalf("expected explicit protection window %v, got %v", time.Hour, cfg.VacuumCnf.ProtectionWindow)
+	}
+}
+
+func TestReadInstanceConfigPreservesExplicitFalseCheckBackupYAML(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.yaml", "vacuum:\n  check_backup: false\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.VacuumCnf.CheckBackup {
+		t.Fatal("expected explicit false check_backup to be preserved")
+	}
+}
+
+func TestReadInstanceConfigPreservesExplicitZeroProtectionWindowJSON(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.json", `{"vacuum":{"protection_window":0}}`))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.VacuumCnf.ProtectionWindow != 0 {
+		t.Fatalf("expected explicit zero protection window, got %v", cfg.VacuumCnf.ProtectionWindow)
+	}
+}
+
+func TestReadInstanceConfigPreservesExplicitFalseCheckBackupTOML(t *testing.T) {
+	cfg, err := ReadInstanceConfig(writeTestConfig(t, "yproxy.toml", "[vacuum]\ncheck_backup = false\nprotection_window = \"0s\"\n"))
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if cfg.VacuumCnf.CheckBackup {
+		t.Fatal("expected explicit false check_backup to be preserved")
+	}
+	if cfg.VacuumCnf.ProtectionWindow != 0 {
+		t.Fatalf("expected explicit zero protection window, got %v", cfg.VacuumCnf.ProtectionWindow)
+	}
+}
+
+func assertDefaultVacuum(t *testing.T, vacuum Vacuum) {
+	t.Helper()
+
+	if vacuum.CheckBackup != DefaultCheckBackup {
+		t.Fatalf("expected default check backup %v, got %v", DefaultCheckBackup, vacuum.CheckBackup)
+	}
+	if vacuum.FileChunkPerSec != DefaultFileChunkPerSec {
+		t.Fatalf("expected default file chunk per sec %v, got %v", DefaultFileChunkPerSec, vacuum.FileChunkPerSec)
+	}
+	if vacuum.TrashRetentionDays != DefaultTrashRetentionDays {
+		t.Fatalf("expected default trash retention days %v, got %v", DefaultTrashRetentionDays, vacuum.TrashRetentionDays)
+	}
+	if vacuum.TrashDeleteWorkers != DefaultTrashDeleteWorkers {
+		t.Fatalf("expected default trash delete workers %v, got %v", DefaultTrashDeleteWorkers, vacuum.TrashDeleteWorkers)
+	}
+	if vacuum.ProtectionWindow != DefaultProtectionWindow {
+		t.Fatalf("expected default protection window %v, got %v", DefaultProtectionWindow, vacuum.ProtectionWindow)
+	}
+}

--- a/config/storage.go
+++ b/config/storage.go
@@ -44,6 +44,82 @@ type Storage struct {
 	EndpointSourceScheme string `json:"storage_endpoint_source_scheme" toml:"storage_endpoint_source_scheme" yaml:"storage_endpoint_source_scheme"`
 }
 
+const (
+	DefaultStorageType = "s3"
+	DefaultStorageConcurrency     = 100
+	DefaultCopyStorageConcurrency = 200
+
+	DefaultEndpointSourceScheme = "https"
+
+	/* 1 GB per  second */
+	DefaultStorageRateLimit = 1024 * 1024 * 1024
+)
+
+type StorageOption func(*Storage)
+
+func WithStorageType(storageType string) StorageOption {
+	return func(s *Storage) {
+		s.StorageType = storageType
+	}
+}
+
+func WithStorageConcurrency(storageConcurrency int64) StorageOption {
+	return func(s *Storage) {
+		s.StorageConcurrency = storageConcurrency
+	}
+}
+
+func WithCopyStorageConcurrency(copyStorageConcurrency int64) StorageOption {
+	return func(s *Storage) {
+		s.CopyStorageConcurrency = copyStorageConcurrency
+	}
+}
+
+func WithStorageRateLimit(storageRateLimit uint64) StorageOption {
+	return func(s *Storage) {
+		s.StorageRateLimit = storageRateLimit
+	}
+}
+
+func WithEndpointSourceScheme(endpointSourceScheme string) StorageOption {
+	return func(s *Storage) {
+		s.EndpointSourceScheme = endpointSourceScheme
+	}
+}
+
+func BuildStorage(opts ...StorageOption) *Storage {
+	s := &Storage{}
+
+	ApplyStorageOptions(s,
+		WithStorageType(DefaultStorageType),
+		WithStorageConcurrency(DefaultStorageConcurrency),
+		WithCopyStorageConcurrency(DefaultCopyStorageConcurrency),
+		WithStorageRateLimit(DefaultStorageRateLimit),
+		WithEndpointSourceScheme(DefaultEndpointSourceScheme),
+	)
+	ApplyStorageOptions(s, opts...)
+
+	return s
+}
+
+func BuildBackupStorage(opts ...StorageOption) *Storage {
+	s := &Storage{}
+
+	ApplyStorageOptions(s,
+		WithStorageType(DefaultStorageType),
+		WithStorageConcurrency(DefaultStorageConcurrency),
+	)
+	ApplyStorageOptions(s, opts...)
+
+	return s
+}
+
+func ApplyStorageOptions(s *Storage, opts ...StorageOption) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
 func (s Storage) ID() string {
 	id, _ := url.JoinPath(s.StorageEndpoint, s.StorageBucket, s.StoragePrefix)
 	return id

--- a/config/storage.go
+++ b/config/storage.go
@@ -45,7 +45,7 @@ type Storage struct {
 }
 
 const (
-	DefaultStorageType = "s3"
+	DefaultStorageType            = "s3"
 	DefaultStorageConcurrency     = 100
 	DefaultCopyStorageConcurrency = 200
 

--- a/config/vacuum.go
+++ b/config/vacuum.go
@@ -2,10 +2,71 @@ package config
 
 import "time"
 
+const (
+	DefaultCheckBackup        = true
+	DefaultFileChunkPerSec    = 1000
+	DefaultTrashRetentionDays = 7
+	DefaultTrashDeleteWorkers = 1
+	DefaultProtectionWindow   = 24 * time.Hour
+)
+
 type Vacuum struct {
 	CheckBackup        bool          `json:"check_backup" toml:"check_backup" yaml:"check_backup"`
 	FileChunkPerSec    int           `json:"file_chunk_per_sec" toml:"file_chunk_per_sec" yaml:"file_chunk_per_sec"`
 	TrashRetentionDays int           `json:"trash_retention_days" toml:"trash_retention_days" yaml:"trash_retention_days"`
 	TrashDeleteWorkers int           `json:"trash_delete_workers" toml:"trash_delete_workers" yaml:"trash_delete_workers"`
 	ProtectionWindow   time.Duration `json:"protection_window" toml:"protection_window" yaml:"protection_window"`
+}
+
+type VacuumOption func(*Vacuum)
+
+func WithCheckBackup(checkBackup bool) VacuumOption {
+	return func(v *Vacuum) {
+		v.CheckBackup = checkBackup
+	}
+}
+
+func WithFileChunkPerSec(fileChunkPerSec int) VacuumOption {
+	return func(v *Vacuum) {
+		v.FileChunkPerSec = fileChunkPerSec
+	}
+}
+
+func WithTrashRetentionDays(trashRetentionDays int) VacuumOption {
+	return func(v *Vacuum) {
+		v.TrashRetentionDays = trashRetentionDays
+	}
+}
+
+func WithTrashDeleteWorkers(trashDeleteWorkers int) VacuumOption {
+	return func(v *Vacuum) {
+		v.TrashDeleteWorkers = trashDeleteWorkers
+	}
+}
+
+func WithProtectionWindow(protectionWindow time.Duration) VacuumOption {
+	return func(v *Vacuum) {
+		v.ProtectionWindow = protectionWindow
+	}
+}
+
+func BuildVacuum(opts ...VacuumOption) *Vacuum {
+	v := &Vacuum{}
+
+	ApplyVacuumOptions(v,
+		WithCheckBackup(DefaultCheckBackup),
+		WithFileChunkPerSec(DefaultFileChunkPerSec),
+		WithTrashRetentionDays(DefaultTrashRetentionDays),
+		WithTrashDeleteWorkers(DefaultTrashDeleteWorkers),
+		WithProtectionWindow(DefaultProtectionWindow),
+	)
+	ApplyVacuumOptions(v, opts...)
+
+	return v
+}
+
+func ApplyVacuumOptions(v *Vacuum, opts ...VacuumOption) {
+	for _, opt := range opts {
+		opt(v)
+	}
 }

--- a/pkg/core/pg/pg.go
+++ b/pkg/core/pg/pg.go
@@ -374,7 +374,6 @@ func ProcessCopy(conn *pgproto3.Backend, prefix string, port uint64, oldCfgPath 
 	if err != nil {
 		return nil
 	}
-	config.EmbedDefaults(&instanceCnf)
 
 	oldStorage, err := storage.NewStorage(&instanceCnf.StorageCnf, "")
 	if err != nil {

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -500,18 +500,18 @@ func TestDeleteGarbageInBucketMovesObjectsWhenCrazyDropDisabled(t *testing.T) {
 		filesInStorage[1].Path: 0,
 	}, nil)
 
+	cnfBackup := *config.InstanceConfig()
+	defer func() {
+		*config.InstanceConfig() = cnfBackup
+	}()
+	config.InstanceConfig().VacuumCnf = *config.BuildVacuum(config.WithCheckBackup(false))
+
 	handler := proc.BasicGarbageMgr{
 		StorageInterractor: storage,
 		DbInterractor:      database,
 		BackupInterractor:  nil,
 		Cnf:                &config.InstanceConfig().VacuumCnf,
 	}
-
-	cnfBackup := *config.InstanceConfig()
-	defer func() {
-		*config.InstanceConfig() = cnfBackup
-	}()
-	config.EmbedDefaults(config.InstanceConfig())
 
 	err := handler.DeleteGarbageInBucket("trash", msg)
 	assert.NoError(t, err)

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -259,7 +259,6 @@ func ProcessCopyExtended(
 		ylogger.Zero.Error().Err(err).Msg("failed to complete request")
 		return nil
 	}
-	config.EmbedDefaults(&sourceInstanceCnf)
 	oldStorage, err := storage.NewStorage(&sourceInstanceCnf.StorageCnf, "")
 	if err != nil {
 		return err


### PR DESCRIPTION
Prefill config defaults before YAML/TOML/JSON decoding so explicit zero and false values from user config are preserved. Move defaults to their config sections and cover the behavior with tests.