### PR TITLE
Fix release workflow via add dependence build-essential

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get dependencies
         run:
-          sudo apt update && sudo apt install -y debhelper
+          sudo apt update && sudo apt install -y build-essential debhelper
 
       - name: Set env
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV


### PR DESCRIPTION
Fix: https://github.com/open-gpdb/yproxy/actions/runs/29726032817/job/88299236495