### PR TITLE
Fix message leak in PutExtended

### DIFF
--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -856,7 +856,7 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 		return nil
 
 	default:
-		err := fmt.Errorf("wrong request type: %s", tp.String())
+		err := fmt.Errorf("wrong request type: %d (%s)", tp, tp.String())
 		ylogger.Zero.Error().Any("type", tp).Err(err).Msg("unknown message type")
 		_ = ycl.ReplyError(err, "wrong request type")
 

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -850,10 +850,15 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 		if err := ProcessDeleteObsolete(msg, s, bs, ycl); err != nil {
 			return err
 		}
+	case message.MessageTypeCopyDone:
+		msg := message.CopyDoneMessage{}
+		msg.Decode(body)
+		return nil
 
 	default:
-		ylogger.Zero.Error().Any("type", tp).Msg("unknown message type")
-		_ = ycl.ReplyError(nil, "wrong request type")
+		err := fmt.Errorf("wrong request type: %s", tp.String())
+		ylogger.Zero.Error().Any("type", tp).Err(err).Msg("unknown message type")
+		_ = ycl.ReplyError(err, "wrong request type")
 
 		return nil
 	}

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -853,10 +853,9 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 	case message.MessageTypeCopyDone:
 		msg := message.CopyDoneMessage{}
 		msg.Decode(body)
-		return nil
-
+		return fmt.Errorf("%s is not expected here", tp.String())
 	default:
-		if replyErr := ycl.ReplyError(err, "wrong request type"); replyErr != nil {
+		if replyErr := ycl.ReplyError(fmt.Errorf("wrong request type: %s", tp.String()), "wrong request type"); replyErr != nil {
 			ylogger.Zero.Error().Err(replyErr).Msg("failed to send error reply")
 		}
 		return nil

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -858,7 +858,10 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 	default:
 		err := fmt.Errorf("wrong request type: %d (%s)", tp, tp.String())
 		ylogger.Zero.Error().Any("type", tp).Err(err).Msg("unknown message type")
-		_ = ycl.ReplyError(err, "wrong request type")
+if replyErr := ycl.ReplyError(err, "wrong request type"); replyErr != nil {
+    ylogger.Zero.Error().Err(replyErr).Msg("failed to send error reply")
+}
+
 
 		return nil
 	}

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -856,13 +856,9 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 		return nil
 
 	default:
-		err := fmt.Errorf("wrong request type: %d (%s)", tp, tp.String())
-		ylogger.Zero.Error().Any("type", tp).Err(err).Msg("unknown message type")
-if replyErr := ycl.ReplyError(err, "wrong request type"); replyErr != nil {
-    ylogger.Zero.Error().Err(replyErr).Msg("failed to send error reply")
-}
-
-
+		if replyErr := ycl.ReplyError(err, "wrong request type"); replyErr != nil {
+			ylogger.Zero.Error().Err(replyErr).Msg("failed to send error reply")
+		}
 		return nil
 	}
 

--- a/pkg/proc/interaction_test.go
+++ b/pkg/proc/interaction_test.go
@@ -1,0 +1,147 @@
+package proc_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yezzey-gp/yproxy/config"
+	"github.com/yezzey-gp/yproxy/pkg/message"
+	"github.com/yezzey-gp/yproxy/pkg/proc"
+)
+
+type procConnTestClient struct {
+	rw           *procConnTestRW
+	op           message.MessageType
+	opStart      time.Time
+	byteOffset   int64
+	externalPath string
+	closed       bool
+}
+
+func newProcConnTestClient(input []byte) *procConnTestClient {
+	return &procConnTestClient{rw: &procConnTestRW{reader: bytes.NewReader(input)}}
+}
+
+func (c *procConnTestClient) ID() uint {
+	return 1
+}
+
+func (c *procConnTestClient) ReplyError(err error, msg string) error {
+	_, _ = c.rw.Write(message.NewErrorMessage(err, msg).Encode())
+	return nil
+}
+
+func (c *procConnTestClient) GetRW() io.ReadWriteCloser {
+	return c.rw
+}
+
+func (c *procConnTestClient) SetOPType(optype message.MessageType) {
+	c.op = optype
+	c.opStart = time.Now()
+}
+
+func (c *procConnTestClient) OPType() message.MessageType {
+	return c.op
+}
+
+func (c *procConnTestClient) OPStart() time.Time {
+	return c.opStart
+}
+
+func (c *procConnTestClient) SetByteOffset(offset int64) {
+	c.byteOffset = offset
+}
+
+func (c *procConnTestClient) ByteOffset() int64 {
+	return c.byteOffset
+}
+
+func (c *procConnTestClient) SetExternalFilePath(path string) {
+	c.externalPath = path
+}
+
+func (c *procConnTestClient) ExternalFilePath() string {
+	return c.externalPath
+}
+
+func (c *procConnTestClient) Close() error {
+	c.closed = true
+	return c.rw.Close()
+}
+
+type procConnTestRW struct {
+	reader *bytes.Reader
+	writer bytes.Buffer
+	closed bool
+}
+
+func (rw *procConnTestRW) Read(p []byte) (int, error) {
+	return rw.reader.Read(p)
+}
+
+func (rw *procConnTestRW) Write(p []byte) (int, error) {
+	return rw.writer.Write(p)
+}
+
+func (rw *procConnTestRW) Close() error {
+	rw.closed = true
+	return nil
+}
+
+func (rw *procConnTestRW) Written() []byte {
+	return rw.writer.Bytes()
+}
+
+func TestProcConnUnknownMessageTypeRepliesErrorWithoutPanic(t *testing.T) {
+	const unknownType = message.MessageType(200)
+
+	ycl := newProcConnTestClient(testPacket(unknownType))
+
+	require.NotPanics(t, func() {
+		err := proc.ProcConn(nil, nil, nil, ycl, &config.Vacuum{})
+		require.NoError(t, err)
+	})
+	require.True(t, ycl.closed)
+	require.Equal(t, unknownType, ycl.OPType())
+
+	body := decodeWrittenPacket(t, ycl.rw.Written())
+	require.Equal(t, message.MessageTypeError, message.MessageType(body[0]))
+
+	errorMessage := message.ErrorMessage{}
+	require.NotPanics(t, func() { errorMessage.Decode(body) })
+	require.Equal(t, "wrong request type", errorMessage.Message)
+	require.Contains(t, errorMessage.Error, "wrong request type")
+}
+
+func TestProcConnCopyDoneDoesNothing(t *testing.T) {
+	ycl := newProcConnTestClient(testPacket(message.MessageTypeCopyDone))
+
+	require.NotPanics(t, func() {
+		err := proc.ProcConn(nil, nil, nil, ycl, &config.Vacuum{})
+		require.NoError(t, err)
+	})
+	require.True(t, ycl.closed)
+	require.Equal(t, message.MessageTypeCopyDone, ycl.OPType())
+	require.Empty(t, ycl.rw.Written())
+}
+
+func testPacket(tp message.MessageType) []byte {
+	body := []byte{byte(tp), 0, 0, 0}
+	packet := make([]byte, 8, 8+len(body))
+	binary.BigEndian.PutUint64(packet, uint64(8+len(body)))
+	return append(packet, body...)
+}
+
+func decodeWrittenPacket(t *testing.T, packet []byte) []byte {
+	t.Helper()
+	require.GreaterOrEqual(t, len(packet), 9)
+
+	packetLen := binary.BigEndian.Uint64(packet[:8])
+	require.Equal(t, uint64(len(packet)), packetLen)
+
+	return packet[8:]
+}

--- a/pkg/proc/interaction_test.go
+++ b/pkg/proc/interaction_test.go
@@ -117,12 +117,13 @@ func TestProcConnUnknownMessageTypeRepliesErrorWithoutPanic(t *testing.T) {
 	require.Contains(t, errorMessage.Error, "wrong request type")
 }
 
-func TestProcConnCopyDoneDoesNothing(t *testing.T) {
+func TestProcConnCopyDoneRepliesErrorWithoutPanic(t *testing.T) {
 	ycl := newProcConnTestClient(testPacket(message.MessageTypeCopyDone))
 
 	require.NotPanics(t, func() {
 		err := proc.ProcConn(nil, nil, nil, ycl, &config.Vacuum{})
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not expected here")
 	})
 	require.True(t, ycl.closed)
 	require.Equal(t, message.MessageTypeCopyDone, ycl.OPType())


### PR DESCRIPTION
In ProcessPutExtended we start worker pool to process upload messages. But in a case of upload error do not wait all messages and exit.

This lead to the situation where MessageTypeCopyDone leaves unprocessed and get to the main ProcConn method

ProcConn has bug with working with unknown messages (like MessageTypeCopyDone) - pass nil as error message where not-nil expected.

The whole process fails with nil dereference.