### PR TITLE
Add metrics for measure delete progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The output consists of 2 categories of metrics:
 |             | `write_req_errors_total` | counter | The total number of errors occurred while processing write requests |
 | Internal    | `request_latency_bucket` | histogram | The number of requests and requests time for each source request |
 |             | `request_size_bucket` | histogram | The number of requests and requests size for each source request |
-| Delete / garbage collection | `delete_process_total` | gauge | Size of the current batch of items found to process by delete/untrashify handlers |
+| Delete / garbage collection | `delete_process_items` | gauge | Size of the current batch of items found to process by delete/untrashify handlers |
 |             | `delete_process_remaining` | gauge | Items left to process by delete/untrashify handlers |
 |             | `delete_process_processed_total` | counter | Cumulative number of items delete/untrashify handlers attempted to delete or move |
 |             | `delete_process_deleted_total` | counter | Cumulative number of items successfully deleted or moved |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ The output consists of 2 categories of metrics:
 |             | `write_req_errors_total` | counter | The total number of errors occurred while processing write requests |
 | Internal    | `request_latency_bucket` | histogram | The number of requests and requests time for each source request |
 |             | `request_size_bucket` | histogram | The number of requests and requests size for each source request |
+| Delete / garbage collection | `delete_process_total` | gauge | Size of the current batch of items found to process by delete/untrashify handlers |
+|             | `delete_process_remaining` | gauge | Items left to process by delete/untrashify handlers |
+|             | `delete_process_processed_total` | counter | Cumulative number of items delete/untrashify handlers attempted to delete or move |
+|             | `delete_process_deleted_total` | counter | Cumulative number of items successfully deleted or moved |
+|             | `delete_process_kept_total` | counter | Cumulative number of items intentionally left in place (skipped, e.g. by the protection window/trash filter, or failed after retries) |
+|             | `delete_request_latency_seconds_bucket` | histogram | Latency of delete-handler list/delete operations |
+|             | `delete_request_size_bucket` | histogram | Number of items returned by a delete-handler list operation |
 
 Internal metrics show latency and size for each source request. Source request is the internal type of query from GP to yproxy. Yproxy performs mostly upload/download requests to S3. But yezzey perform requests multiple species. They are named as source request. We measure source requests:
 ```
@@ -92,6 +99,17 @@ UNTRASHIFY
 COLLECT OBSOLETE
 DELETE OBSOLETE
 ```
+
+Delete/garbage-collection metrics are labeled per `bucket` (since yproxy can
+manage multiple storage buckets) and per `operation`, one of:
+```
+UNTRASHIFY      # HandleUntrashifyFile
+DELETE_GARBAGE  # DeleteGarbageInBucket
+DELETE_PREFIX   # DeletePrefixInBucket
+```
+`delete_request_latency_seconds` is additionally labeled by `stage`
+(`list` or `delete`), distinguishing the time spent listing objects from the
+time spent on each individual delete/move call.
 
 <details>
   <summary>Example of gathered metrics for a simple yezzey query:</summary>

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ The output consists of 2 categories of metrics:
 |             | `write_req_errors_total` | counter | The total number of errors occurred while processing write requests |
 | Internal    | `request_latency_bucket` | histogram | The number of requests and requests time for each source request |
 |             | `request_size_bucket` | histogram | The number of requests and requests size for each source request |
-| Delete / garbage collection | `delete_process_items` | gauge | Size of the current batch of items found to process by delete/untrashify handlers |
-|             | `delete_process_remaining` | gauge | Items left to process by delete/untrashify handlers |
-|             | `delete_process_processed_total` | counter | Cumulative number of items delete/untrashify handlers attempted to delete or move |
+| Delete / garbage collection | `delete_process_items` | gauge | Size of the current batch of items found to process by delete handlers |
+|             | `delete_process_remaining` | gauge | Items left to process by delete handlers |
+|             | `delete_process_processed_total` | counter | Cumulative number of items delete handlers attempted to delete or move |
 |             | `delete_process_deleted_total` | counter | Cumulative number of items successfully deleted or moved |
 |             | `delete_process_kept_total` | counter | Cumulative number of items intentionally left in place (skipped, e.g. by the protection window/trash filter, or failed after retries) |
 |             | `delete_request_latency_seconds_bucket` | histogram | Latency of delete-handler list/delete operations |
@@ -103,13 +103,17 @@ DELETE OBSOLETE
 Delete/garbage-collection metrics are labeled per `bucket` (since yproxy can
 manage multiple storage buckets) and per `operation`, one of:
 ```
-UNTRASHIFY      # HandleUntrashifyFile
 DELETE_GARBAGE  # DeleteGarbageInBucket
 DELETE_PREFIX   # DeletePrefixInBucket
 ```
 `delete_request_latency_seconds` is additionally labeled by `stage`
 (`list` or `delete`), distinguishing the time spent listing objects from the
 time spent on each individual delete/move call.
+
+`HandleUntrashifyFile` restores files from trash rather than deleting them,
+so it does not report these metrics - it still logs an Info-level line when
+it starts and finishes, plus a periodic Info-level progress line every
+50000 processed items.
 
 <details>
   <summary>Example of gathered metrics for a simple yezzey query:</summary>

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/rs/zerolog v1.31.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.11.1
@@ -37,9 +38,9 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/pkg/metrics/delete_metrics.go
+++ b/pkg/metrics/delete_metrics.go
@@ -1,11 +1,17 @@
 package metrics
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+// ProgressLogInterval is how often (in cumulative processed items) callers
+// should emit an Info-level progress log line, to keep log volume bounded
+// during long-running delete/untrashify operations.
+const ProgressLogInterval = 50000
 
 var (
 	itemCountBuckets = []float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 50000}
@@ -53,6 +59,7 @@ var (
 type DeleteOpTracker struct {
 	bucket    string
 	operation string
+	processed atomic.Int64
 }
 
 func NewDeleteOpTracker(bucket, operation string) *DeleteOpTracker {
@@ -80,8 +87,11 @@ func (t *DeleteOpTracker) ObserveDelete(d time.Duration) {
 	DeleteRequestLatency.With(prometheus.Labels{"bucket": t.bucket, "operation": t.operation, "stage": "delete"}).Observe(d.Seconds())
 }
 
-func (t *DeleteOpTracker) AddProcessed(n int) {
+// AddProcessed records n more processed items and returns the cumulative
+// processed count for this tracker, for use with ProgressLogInterval.
+func (t *DeleteOpTracker) AddProcessed(n int) int64 {
 	DeleteProcessProcessed.With(t.labels()).Add(float64(n))
+	return t.processed.Add(int64(n))
 }
 
 func (t *DeleteOpTracker) AddDeleted(n int) {

--- a/pkg/metrics/delete_metrics.go
+++ b/pkg/metrics/delete_metrics.go
@@ -17,7 +17,7 @@ var (
 	itemCountBuckets = []float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 50000}
 
 	DeleteProcessTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "delete_process_total",
+		Name: "delete_process_items",
 		Help: "Size of the current batch of items found to process by delete/untrashify handlers",
 	}, []string{"bucket", "operation"})
 

--- a/pkg/metrics/delete_metrics.go
+++ b/pkg/metrics/delete_metrics.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	itemCountBuckets = []float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 50000}
+
+	DeleteProcessTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "delete_process_total",
+		Help: "Size of the current batch of items found to process by delete/untrashify handlers",
+	}, []string{"bucket", "operation"})
+
+	DeleteProcessRemaining = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "delete_process_remaining",
+		Help: "Items left to process by delete/untrashify handlers",
+	}, []string{"bucket", "operation"})
+
+	DeleteProcessProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "delete_process_processed_total",
+		Help: "Cumulative number of items delete/untrashify handlers attempted to delete or move",
+	}, []string{"bucket", "operation"})
+
+	DeleteProcessDeleted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "delete_process_deleted_total",
+		Help: "Cumulative number of items successfully deleted or moved",
+	}, []string{"bucket", "operation"})
+
+	DeleteProcessKept = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "delete_process_kept_total",
+		Help: "Cumulative number of items intentionally left in place (skipped or failed after retries)",
+	}, []string{"bucket", "operation"})
+
+	DeleteRequestLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "delete_request_latency_seconds",
+		Help:    "Latency of delete-handler list/delete operations",
+		Buckets: latencyBuckets,
+	}, []string{"bucket", "operation", "stage"})
+
+	DeleteRequestSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "delete_request_size",
+		Help:    "Number of items returned by a delete-handler list operation",
+		Buckets: itemCountBuckets,
+	}, []string{"bucket", "operation"})
+)
+
+// DeleteOpTracker reports per-bucket, per-operation progress metrics for the
+// long-running delete/untrashify handlers in pkg/proc/delete_handler.go.
+type DeleteOpTracker struct {
+	bucket    string
+	operation string
+}
+
+func NewDeleteOpTracker(bucket, operation string) *DeleteOpTracker {
+	return &DeleteOpTracker{bucket: bucket, operation: operation}
+}
+
+func (t *DeleteOpTracker) labels() prometheus.Labels {
+	return prometheus.Labels{"bucket": t.bucket, "operation": t.operation}
+}
+
+func (t *DeleteOpTracker) SetTotal(n int) {
+	DeleteProcessTotal.With(t.labels()).Set(float64(n))
+}
+
+func (t *DeleteOpTracker) SetRemaining(n int) {
+	DeleteProcessRemaining.With(t.labels()).Set(float64(n))
+}
+
+func (t *DeleteOpTracker) ObserveList(d time.Duration, itemCount int) {
+	DeleteRequestLatency.With(prometheus.Labels{"bucket": t.bucket, "operation": t.operation, "stage": "list"}).Observe(d.Seconds())
+	DeleteRequestSize.With(t.labels()).Observe(float64(itemCount))
+}
+
+func (t *DeleteOpTracker) ObserveDelete(d time.Duration) {
+	DeleteRequestLatency.With(prometheus.Labels{"bucket": t.bucket, "operation": t.operation, "stage": "delete"}).Observe(d.Seconds())
+}
+
+func (t *DeleteOpTracker) AddProcessed(n int) {
+	DeleteProcessProcessed.With(t.labels()).Add(float64(n))
+}
+
+func (t *DeleteOpTracker) AddDeleted(n int) {
+	DeleteProcessDeleted.With(t.labels()).Add(float64(n))
+}
+
+func (t *DeleteOpTracker) AddKept(n int) {
+	DeleteProcessKept.With(t.labels()).Add(float64(n))
+}

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yezzey-gp/yproxy/pkg/backups"
 	"github.com/yezzey-gp/yproxy/pkg/database"
 	"github.com/yezzey-gp/yproxy/pkg/message"
+	"github.com/yezzey-gp/yproxy/pkg/metrics"
 	"github.com/yezzey-gp/yproxy/pkg/object"
 	"github.com/yezzey-gp/yproxy/pkg/storage"
 	"github.com/yezzey-gp/yproxy/pkg/ylogger"
@@ -65,29 +66,47 @@ func RegPathFromTrasnPath(p string, segnum int) string {
 
 // HandleUntrashifyFile implements GarbageMgr.
 func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) error {
+	start := time.Now()
+	bucket := dh.StorageInterractor.DefaultBucket()
+	t := metrics.NewDeleteOpTracker(bucket, "UNTRASHIFY")
 
-	ylogger.Zero.Info().Str("path", msg.Name).Msg("listing prefix")
+	listStart := time.Now()
 	objectMetas, err := dh.StorageInterractor.ListPath(msg.Name, true, nil)
 	if err != nil {
 		return errors.Wrap(err, "could not list objects")
 	}
+	t.ObserveList(time.Since(listStart), len(objectMetas))
+	t.SetTotal(len(objectMetas))
+	t.SetRemaining(len(objectMetas))
+	ylogger.Zero.Info().Str("bucket", bucket).Str("path", msg.Name).Int("amount", len(objectMetas)).Msg("untrashify started")
 
 	for _, file := range objectMetas {
-		ylogger.Zero.Info().Str("file", file.Path).Str("dest-path", RegPathFromTrasnPath(file.Path, int(msg.Segnum))).Msg("file will be untrashified")
+		ylogger.Zero.Debug().Str("file", file.Path).Str("dest-path", RegPathFromTrasnPath(file.Path, int(msg.Segnum))).Msg("file will be untrashified")
 	}
 
 	if !msg.Confirm { //do not delete files if no confirmation flag provided
 		return nil
 	}
 
+	deleted := 0
 	for _, file := range objectMetas {
 		tp := RegPathFromTrasnPath(file.Path, int(msg.Segnum))
 		/* XXX: fix this */
-		err = dh.StorageInterractor.MoveObject(dh.StorageInterractor.DefaultBucket(), file.Path, tp)
+		opStart := time.Now()
+		err = dh.StorageInterractor.MoveObject(bucket, file.Path, tp)
+		t.ObserveDelete(time.Since(opStart))
+		t.AddProcessed(1)
 		if err != nil {
+			t.AddKept(len(objectMetas) - deleted)
+			t.SetRemaining(len(objectMetas) - deleted)
 			return err
 		}
+		deleted++
+		t.AddDeleted(1)
+		t.SetRemaining(len(objectMetas) - deleted)
 	}
+
+	ylogger.Zero.Info().Str("bucket", bucket).Int("deleted", deleted).Dur("elapsed", time.Since(start)).Msg("untrashify finished")
 
 	return nil
 }
@@ -100,6 +119,9 @@ func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) e
  * Example: TestDeleteGarbageInBucketMovesObjectsWhenCrazyDropDisabled
  */
 func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.DeleteMessage) error {
+	start := time.Now()
+	t := metrics.NewDeleteOpTracker(bucket, "DELETE_GARBAGE")
+
 	fileList, err := dh.ListGarbageFiles(bucket, msg)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete file")
@@ -108,17 +130,19 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 	if err != nil {
 		return err
 	}
-	ylogger.Zero.Info().Str("bucket", bucket).Int("amount", len(uploads)).Msg("multipart uploads will be aborted")
+	t.SetTotal(len(fileList))
+	t.SetRemaining(len(fileList))
+	ylogger.Zero.Info().Str("bucket", bucket).Int("files", len(fileList)).Int("uploads", len(uploads)).Msg("garbage delete started")
 
 	for _, file := range fileList {
-		ylogger.Zero.Info().Str("bucket", bucket).Bool("crazy mode", msg.CrazyDrop).Str("file", file.Path).Msg("file will be deleted")
+		ylogger.Zero.Debug().Str("bucket", bucket).Bool("crazy mode", msg.CrazyDrop).Str("file", file.Path).Msg("file will be deleted")
 	}
 	for _, upload := range uploads {
-		ylogger.Zero.Info().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
+		ylogger.Zero.Debug().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
 	}
 
 	if !msg.Confirm { // Do not delete files if no confirmation flag provided
-		ylogger.Zero.Info().Msg("do not perform actual delete files as no confirmation flag provided")
+		ylogger.Zero.Info().Str("bucket", bucket).Msg("do not perform actual delete files as no confirmation flag provided")
 		return nil
 	}
 
@@ -136,7 +160,7 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 		failedActionMsg = "failed to delete some files"
 		failedFilesMsg = "some files were not deleted"
 		operate = func(file *object.ObjectInfo) error {
-			ylogger.Zero.Info().Str("bucket", bucket).Str("path", file.Path).Msg("immediately delete garbage file")
+			ylogger.Zero.Debug().Str("bucket", bucket).Str("path", file.Path).Msg("immediately delete garbage file")
 			return dh.StorageInterractor.DeleteObject(bucket, file.Path)
 		}
 	} else {
@@ -144,11 +168,12 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 		failedFilesMsg = "some files were not moved"
 		operate = func(file *object.ObjectInfo) error {
 			tp := TrashPathFromRegPath(file.Path, int(msg.Segnum))
-			ylogger.Zero.Info().Str("bucket", bucket).Str("path", file.Path).Msg("move garbage file to trash")
+			ylogger.Zero.Debug().Str("bucket", bucket).Str("path", file.Path).Msg("move garbage file to trash")
 			return dh.StorageInterractor.MoveObject(bucket, file.Path, tp)
 		}
 	}
 
+	deleted := 0
 	var failed []*object.ObjectInfo
 	for retryCount := 0; len(fileList) > 0 && retryCount < 10; retryCount++ {
 		for _, file := range fileList {
@@ -156,17 +181,25 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 			if err := limiter.Wait(ctx); err != nil {
 				break
 			}
+			opStart := time.Now()
 			err = operate(file)
+			t.ObserveDelete(time.Since(opStart))
+			t.AddProcessed(1)
 			if err != nil {
 				ylogger.Zero.Warn().AnErr("err", err).Str("bucket", bucket).Str("file", file.Path).Msg(failedActionMsg)
 				failed = append(failed, file)
+			} else {
+				deleted++
+				t.AddDeleted(1)
 			}
 		}
 		fileList = failed
+		t.SetRemaining(len(fileList))
 		failed = make([]*object.ObjectInfo, 0)
 	}
 
 	if len(fileList) > 0 {
+		t.AddKept(len(fileList))
 		ylogger.Zero.Error().Str("bucket", bucket).Int("failed files count", len(fileList)).Msg(failedFilesMsg)
 		ylogger.Zero.Error().Str("bucket", bucket).Any("failed files", fileList).Msg(failedActionMsg)
 		return errors.Wrap(err, failedActionMsg)
@@ -181,6 +214,8 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 			return err
 		}
 	}
+
+	ylogger.Zero.Info().Str("bucket", bucket).Int("deleted", deleted).Dur("elapsed", time.Since(start)).Msg("garbage delete finished")
 
 	return nil
 }
@@ -198,12 +233,13 @@ func (dh *BasicGarbageMgr) ListDelete2Files(bucket string, msg message.Delete2Me
 	var err error
 
 	// List files in storage
-	ylogger.Zero.Info().Str("path", msg.Prefix).Msg("listing prefix")
+	listStart := time.Now()
 	objectMetas, err := dh.StorageInterractor.ListBucketPath(bucket, msg.Prefix, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list objects")
 	}
-	ylogger.Zero.Info().Int("amount", len(objectMetas)).Msg("objects count")
+	metrics.NewDeleteOpTracker(bucket, "DELETE_PREFIX").ObserveList(time.Since(listStart), len(objectMetas))
+	ylogger.Zero.Debug().Str("path", msg.Prefix).Int("amount", len(objectMetas)).Msg("objects listed")
 
 	filesToDelete := make([]*object.ObjectInfo, 0)
 	for i := range objectMetas {
@@ -214,12 +250,10 @@ func (dh *BasicGarbageMgr) ListDelete2Files(bucket string, msg message.Delete2Me
 
 	}
 
-	ylogger.Zero.Info().Int("amount", len(filesToDelete)).Msg("files will be deleted")
-
 	return filesToDelete, nil
 }
 
-func (dh *BasicGarbageMgr) garbageTrashParallel(bucket string, fileList []*object.ObjectInfo) ([]*object.ObjectInfo, error) {
+func (dh *BasicGarbageMgr) garbageTrashParallel(bucket string, fileList []*object.ObjectInfo, t *metrics.DeleteOpTracker) ([]*object.ObjectInfo, error) {
 	workerCount := dh.Cnf.TrashDeleteWorkers
 	if workerCount <= 0 {
 		workerCount = config.DefaultTrashDeleteWorkers
@@ -238,9 +272,15 @@ func (dh *BasicGarbageMgr) garbageTrashParallel(bucket string, fileList []*objec
 	for i := 0; i < workerCount; i++ {
 		wg.Go(func() {
 			for file := range jobs {
-				if err := dh.StorageInterractor.DeleteObject(bucket, file.Path); err != nil {
+				opStart := time.Now()
+				err := dh.StorageInterractor.DeleteObject(bucket, file.Path)
+				t.ObserveDelete(time.Since(opStart))
+				t.AddProcessed(1)
+				if err != nil {
 					ylogger.Zero.Warn().AnErr("err", err).Str("bucket", bucket).Str("file", file.Path).Msg("failed to delete garbage file")
 					failedCh <- file
+				} else {
+					t.AddDeleted(1)
 				}
 			}
 		})
@@ -266,6 +306,9 @@ func (dh *BasicGarbageMgr) garbageTrashParallel(bucket string, fileList []*objec
 }
 
 func (dh *BasicGarbageMgr) DeletePrefixInBucket(bucket string, msg message.Delete2Message) error {
+	start := time.Now()
+	t := metrics.NewDeleteOpTracker(bucket, "DELETE_PREFIX")
+
 	fileList, err := dh.ListDelete2Files(bucket, msg) // Return the list of files to be deleted
 	if err != nil {
 		return errors.Wrap(err, "failed to delete file")
@@ -274,39 +317,52 @@ func (dh *BasicGarbageMgr) DeletePrefixInBucket(bucket string, msg message.Delet
 	if err != nil {
 		return err
 	}
-	ylogger.Zero.Info().Str("bucket", bucket).Int("amount", len(uploads)).Msg("multipart uploads will be aborted")
+	ylogger.Zero.Info().Str("bucket", bucket).Int("files", len(fileList)).Int("uploads", len(uploads)).Msg("prefix delete started")
 
 	for _, file := range fileList {
-		ylogger.Zero.Info().Str("bucket", bucket).Str("file", file.Path).Msg("file will be deleted")
+		ylogger.Zero.Debug().Str("bucket", bucket).Str("file", file.Path).Msg("file will be deleted")
 	}
 	for _, upload := range uploads {
-		ylogger.Zero.Info().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
+		ylogger.Zero.Debug().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
 	}
 
 	if !msg.Confirm { // Do not delete files if no confirmation flag provided
-		ylogger.Zero.Info().Msg("do not perform actual delete files as no confirmation flag provided")
+		ylogger.Zero.Info().Str("bucket", bucket).Msg("do not perform actual delete files as no confirmation flag provided")
 		return nil
 	}
 	if !strings.Contains(msg.Prefix, "trash") {
-		ylogger.Zero.Info().Msg("prefix doesn't contain trash aborted")
+		ylogger.Zero.Info().Str("bucket", bucket).Msg("prefix doesn't contain trash aborted")
 		return nil
 	}
+
+	t.SetTotal(len(fileList))
 	trashRetention := time.Hour * 24 * time.Duration(dh.Cnf.TrashRetentionDays)
 	filtered := fileList[:0]
+	skipped := 0
 	for _, file := range fileList {
 		if strings.Contains(file.Path, "trash") && file.LastMod.Add(trashRetention).Unix() < time.Now().Unix() {
 			filtered = append(filtered, file)
+		} else {
+			skipped++
 		}
 	}
 	fileList = filtered
+	if skipped > 0 {
+		t.AddKept(skipped)
+	}
+	toDelete := len(fileList)
+	t.SetRemaining(toDelete)
+
 	for retryCount := 0; len(fileList) > 0 && retryCount < 10; retryCount++ {
-		fileList, err = dh.garbageTrashParallel(bucket, fileList)
+		fileList, err = dh.garbageTrashParallel(bucket, fileList, t)
+		t.SetRemaining(len(fileList))
 		if err == nil {
 			break
 		}
 	}
 
 	if len(fileList) > 0 {
+		t.AddKept(len(fileList))
 		ylogger.Zero.Error().Str("bucket", bucket).Int("failed files count", len(fileList)).Msg("some files were not deleted")
 		ylogger.Zero.Error().Str("bucket", bucket).Any("failed files", fileList).Msg("failed to delete some files")
 		return errors.Wrap(err, "failed to delete some files")
@@ -317,6 +373,8 @@ func (dh *BasicGarbageMgr) DeletePrefixInBucket(bucket string, msg message.Delet
 			return err
 		}
 	}
+
+	ylogger.Zero.Info().Str("bucket", bucket).Int("deleted", toDelete).Int("kept", skipped).Dur("elapsed", time.Since(start)).Msg("prefix delete finished")
 
 	return nil
 }
@@ -363,12 +421,13 @@ func (dh *BasicGarbageMgr) ListGarbageFiles(bucket string, msg message.DeleteMes
 	}
 
 	// List files in storage
-	ylogger.Zero.Info().Str("path", msg.Name).Msg("listing prefix")
+	listStart := time.Now()
 	objectMetas, err := dh.StorageInterractor.ListBucketPath(bucket, msg.Name, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list objects")
 	}
-	ylogger.Zero.Info().Int("amount", len(objectMetas)).Msg("objects count")
+	metrics.NewDeleteOpTracker(bucket, "DELETE_GARBAGE").ObserveList(time.Since(listStart), len(objectMetas))
+	ylogger.Zero.Debug().Str("path", msg.Name).Int("amount", len(objectMetas)).Msg("objects listed")
 
 	vi, ei, err := dh.DbInterractor.GetVirtualExpireIndexes(msg.Port)
 	if err != nil {

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -95,7 +95,12 @@ func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) e
 		opStart := time.Now()
 		err = dh.StorageInterractor.MoveObject(bucket, file.Path, tp)
 		t.ObserveDelete(time.Since(opStart))
-		t.AddProcessed(1)
+		processedTotal := t.AddProcessed(1)
+		if processedTotal%metrics.ProgressLogInterval == 0 {
+			ylogger.Zero.Info().Str("bucket", bucket).Str("operation", "UNTRASHIFY").
+				Int64("processed", processedTotal).Int("deleted", deleted).
+				Int("remaining", len(objectMetas)-deleted).Msg("untrashify progress")
+		}
 		if err != nil {
 			t.AddKept(len(objectMetas) - deleted)
 			t.SetRemaining(len(objectMetas) - deleted)
@@ -173,6 +178,7 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 		}
 	}
 
+	totalFiles := len(fileList)
 	deleted := 0
 	var failed []*object.ObjectInfo
 	for retryCount := 0; len(fileList) > 0 && retryCount < 10; retryCount++ {
@@ -184,7 +190,12 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 			opStart := time.Now()
 			err = operate(file)
 			t.ObserveDelete(time.Since(opStart))
-			t.AddProcessed(1)
+			processedTotal := t.AddProcessed(1)
+			if processedTotal%metrics.ProgressLogInterval == 0 {
+				ylogger.Zero.Info().Str("bucket", bucket).Str("operation", "DELETE_GARBAGE").
+					Int64("processed", processedTotal).Int("deleted", deleted).
+					Int("remaining", totalFiles-deleted).Msg("garbage delete progress")
+			}
 			if err != nil {
 				ylogger.Zero.Warn().AnErr("err", err).Str("bucket", bucket).Str("file", file.Path).Msg(failedActionMsg)
 				failed = append(failed, file)
@@ -275,7 +286,11 @@ func (dh *BasicGarbageMgr) garbageTrashParallel(bucket string, fileList []*objec
 				opStart := time.Now()
 				err := dh.StorageInterractor.DeleteObject(bucket, file.Path)
 				t.ObserveDelete(time.Since(opStart))
-				t.AddProcessed(1)
+				processedTotal := t.AddProcessed(1)
+				if processedTotal%metrics.ProgressLogInterval == 0 {
+					ylogger.Zero.Info().Str("bucket", bucket).Str("operation", "DELETE_PREFIX").
+						Int64("processed", processedTotal).Msg("prefix delete progress")
+				}
 				if err != nil {
 					ylogger.Zero.Warn().AnErr("err", err).Str("bucket", bucket).Str("file", file.Path).Msg("failed to delete garbage file")
 					failedCh <- file

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -64,12 +64,8 @@ func RegPathFromTrasnPath(p string, segnum int) string {
 	return destPath
 }
 
-// HandleUntrashifyFile implements GarbageMgr.
-//
-// This restores files from trash rather than deleting them, so it
-// intentionally does not report the delete/garbage-collection Prometheus
-// metrics (those count deletions, not restores) - only progress logging is
-// kept.
+// This restores files from trash rather than deleting them,
+// Just logging progress logging here
 func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) error {
 	start := time.Now()
 	bucket := dh.StorageInterractor.DefaultBucket()
@@ -81,7 +77,7 @@ func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) e
 	ylogger.Zero.Info().Str("bucket", bucket).Str("path", msg.Name).Int("amount", len(objectMetas)).Msg("untrashify started")
 
 	for _, file := range objectMetas {
-		ylogger.Zero.Debug().Str("file", file.Path).Str("dest-path", RegPathFromTrasnPath(file.Path, int(msg.Segnum))).Msg("file will be untrashified")
+		ylogger.Zero.Info().Str("file", file.Path).Str("dest-path", RegPathFromTrasnPath(file.Path, int(msg.Segnum))).Msg("file will be untrashified")
 	}
 
 	if !msg.Confirm { //do not delete files if no confirmation flag provided
@@ -134,10 +130,10 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 	ylogger.Zero.Info().Str("bucket", bucket).Int("files", len(fileList)).Int("uploads", len(uploads)).Msg("garbage delete started")
 
 	for _, file := range fileList {
-		ylogger.Zero.Debug().Str("bucket", bucket).Bool("crazy mode", msg.CrazyDrop).Str("file", file.Path).Msg("file will be deleted")
+		ylogger.Zero.Info().Str("bucket", bucket).Bool("crazy mode", msg.CrazyDrop).Str("file", file.Path).Msg("file will be deleted")
 	}
 	for _, upload := range uploads {
-		ylogger.Zero.Debug().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
+		ylogger.Zero.Info().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
 	}
 
 	if !msg.Confirm { // Do not delete files if no confirmation flag provided
@@ -332,7 +328,7 @@ func (dh *BasicGarbageMgr) DeletePrefixInBucket(bucket string, msg message.Delet
 		ylogger.Zero.Debug().Str("bucket", bucket).Str("file", file.Path).Msg("file will be deleted")
 	}
 	for _, upload := range uploads {
-		ylogger.Zero.Debug().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
+		ylogger.Zero.Info().Str("bucket", bucket).Str("uploadId", upload).Msg("upload will be aborted")
 	}
 
 	if !msg.Confirm { // Do not delete files if no confirmation flag provided

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -85,6 +85,7 @@ func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) e
 	}
 
 	if !msg.Confirm { //do not delete files if no confirmation flag provided
+		t.SetRemaining(0)
 		return nil
 	}
 

--- a/pkg/proc/delete_handler.go
+++ b/pkg/proc/delete_handler.go
@@ -65,19 +65,19 @@ func RegPathFromTrasnPath(p string, segnum int) string {
 }
 
 // HandleUntrashifyFile implements GarbageMgr.
+//
+// This restores files from trash rather than deleting them, so it
+// intentionally does not report the delete/garbage-collection Prometheus
+// metrics (those count deletions, not restores) - only progress logging is
+// kept.
 func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) error {
 	start := time.Now()
 	bucket := dh.StorageInterractor.DefaultBucket()
-	t := metrics.NewDeleteOpTracker(bucket, "UNTRASHIFY")
 
-	listStart := time.Now()
 	objectMetas, err := dh.StorageInterractor.ListPath(msg.Name, true, nil)
 	if err != nil {
 		return errors.Wrap(err, "could not list objects")
 	}
-	t.ObserveList(time.Since(listStart), len(objectMetas))
-	t.SetTotal(len(objectMetas))
-	t.SetRemaining(len(objectMetas))
 	ylogger.Zero.Info().Str("bucket", bucket).Str("path", msg.Name).Int("amount", len(objectMetas)).Msg("untrashify started")
 
 	for _, file := range objectMetas {
@@ -85,31 +85,24 @@ func (dh *BasicGarbageMgr) HandleUntrashifyFile(msg message.UntrashifyMessage) e
 	}
 
 	if !msg.Confirm { //do not delete files if no confirmation flag provided
-		t.SetRemaining(0)
 		return nil
 	}
 
 	deleted := 0
-	for _, file := range objectMetas {
+	for i, file := range objectMetas {
 		tp := RegPathFromTrasnPath(file.Path, int(msg.Segnum))
 		/* XXX: fix this */
-		opStart := time.Now()
 		err = dh.StorageInterractor.MoveObject(bucket, file.Path, tp)
-		t.ObserveDelete(time.Since(opStart))
-		processedTotal := t.AddProcessed(1)
-		if processedTotal%metrics.ProgressLogInterval == 0 {
+		processed := i + 1
+		if processed%metrics.ProgressLogInterval == 0 {
 			ylogger.Zero.Info().Str("bucket", bucket).Str("operation", "UNTRASHIFY").
-				Int64("processed", processedTotal).Int("deleted", deleted).
+				Int("processed", processed).Int("deleted", deleted).
 				Int("remaining", len(objectMetas)-deleted).Msg("untrashify progress")
 		}
 		if err != nil {
-			t.AddKept(len(objectMetas) - deleted)
-			t.SetRemaining(len(objectMetas) - deleted)
 			return err
 		}
 		deleted++
-		t.AddDeleted(1)
-		t.SetRemaining(len(objectMetas) - deleted)
 	}
 
 	ylogger.Zero.Info().Str("bucket", bucket).Int("deleted", deleted).Dur("elapsed", time.Since(start)).Msg("untrashify finished")
@@ -166,7 +159,7 @@ func (dh *BasicGarbageMgr) DeleteGarbageInBucket(bucket string, msg message.Dele
 		failedActionMsg = "failed to delete some files"
 		failedFilesMsg = "some files were not deleted"
 		operate = func(file *object.ObjectInfo) error {
-			ylogger.Zero.Debug().Str("bucket", bucket).Str("path", file.Path).Msg("immediately delete garbage file")
+			ylogger.Zero.Info().Str("bucket", bucket).Str("path", file.Path).Msg("immediately delete garbage file")
 			return dh.StorageInterractor.DeleteObject(bucket, file.Path)
 		}
 	} else {

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -7,14 +7,35 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/yezzey-gp/yproxy/config"
 	"github.com/yezzey-gp/yproxy/pkg/message"
+	"github.com/yezzey-gp/yproxy/pkg/metrics"
 	mock "github.com/yezzey-gp/yproxy/pkg/mock"
 	"github.com/yezzey-gp/yproxy/pkg/object"
 	"github.com/yezzey-gp/yproxy/pkg/proc"
 	"go.uber.org/mock/gomock"
 )
+
+// histogramSampleCount returns how many observations were recorded for the
+// given label set of a HistogramVec, by reading back the collected metric.
+func histogramSampleCount(t *testing.T, vec *prometheus.HistogramVec, labels prometheus.Labels) uint64 {
+	t.Helper()
+
+	hist, ok := vec.With(labels).(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("observer for labels %v is not a prometheus.Histogram", labels)
+	}
+
+	var m dto.Metric
+	if err := hist.Write(&m); err != nil {
+		t.Fatalf("failed to write histogram metric: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
 
 func TestFilesToDeletion(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -515,4 +536,222 @@ func TestDeleteGarbageInBucketMovesObjectsWhenCrazyDropDisabled(t *testing.T) {
 
 	err := handler.DeleteGarbageInBucket("trash", msg)
 	assert.NoError(t, err)
+}
+
+func TestHandleUntrashifyFileRecordsMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const bucket = "untrashify-metrics-bucket"
+
+	msg := message.UntrashifyMessage{
+		Name:    "path",
+		Segnum:  60,
+		Confirm: true,
+	}
+
+	filesInStorage := []*object.ObjectInfo{
+		{Path: "trash/segments_005/seg60/basebackups_005/yezzey/file1"},
+		{Path: "trash/segments_005/seg60/basebackups_005/yezzey/file2"},
+	}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().DefaultBucket().Return(bucket)
+	storage.EXPECT().ListPath(msg.Name, true, nil).Return(filesInStorage, nil)
+	storage.EXPECT().MoveObject(bucket, filesInStorage[0].Path, proc.RegPathFromTrasnPath(filesInStorage[0].Path, int(msg.Segnum))).Return(nil)
+	storage.EXPECT().MoveObject(bucket, filesInStorage[1].Path, proc.RegPathFromTrasnPath(filesInStorage[1].Path, int(msg.Segnum))).Return(nil)
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+	}
+
+	err := handler.HandleUntrashifyFile(msg)
+	assert.NoError(t, err)
+
+	labels := prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY"}
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessProcessed.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
+
+	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY", "stage": "list"}))
+	assert.EqualValues(t, 2, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY", "stage": "delete"}))
+	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestSize, labels))
+}
+
+func TestHandleUntrashifyFileRecordsKeptOnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const bucket = "untrashify-metrics-failure-bucket"
+
+	msg := message.UntrashifyMessage{
+		Name:    "path",
+		Segnum:  60,
+		Confirm: true,
+	}
+
+	filesInStorage := []*object.ObjectInfo{
+		{Path: "trash/segments_005/seg60/basebackups_005/yezzey/file1"},
+		{Path: "trash/segments_005/seg60/basebackups_005/yezzey/file2"},
+	}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().DefaultBucket().Return(bucket)
+	storage.EXPECT().ListPath(msg.Name, true, nil).Return(filesInStorage, nil)
+	storage.EXPECT().MoveObject(bucket, filesInStorage[0].Path, proc.RegPathFromTrasnPath(filesInStorage[0].Path, int(msg.Segnum))).Return(errors.New("move failed"))
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+	}
+
+	err := handler.HandleUntrashifyFile(msg)
+	assert.Error(t, err)
+
+	labels := prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY"}
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
+}
+
+func TestDeleteGarbageInBucketRecordsMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const bucket = "garbage-metrics-bucket"
+
+	msg := message.DeleteMessage{
+		Name:      "path",
+		Port:      6000,
+		Segnum:    0,
+		Confirm:   true,
+		CrazyDrop: false,
+	}
+
+	filesInStorage := []*object.ObjectInfo{
+		{Path: "segments_005/seg0/basebackups_005/yezzey/file1"},
+		{Path: "segments_005/seg0/basebackups_005/yezzey/file2"},
+	}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().ListBucketPath(bucket, msg.Name, true).Return(filesInStorage, nil)
+	storage.EXPECT().ListFailedMultipartUploads(bucket).Return(map[string]string{}, nil)
+	storage.EXPECT().MoveObject(bucket, filesInStorage[0].Path, proc.TrashPathFromRegPath(filesInStorage[0].Path, int(msg.Segnum))).Return(nil)
+	storage.EXPECT().MoveObject(bucket, filesInStorage[1].Path, proc.TrashPathFromRegPath(filesInStorage[1].Path, int(msg.Segnum))).Return(nil)
+
+	database := mock.NewMockDatabaseInterractor(ctrl)
+	database.EXPECT().GetVirtualExpireIndexes(msg.Port).Return(map[string]bool{}, map[string]uint64{
+		filesInStorage[0].Path: 0,
+		filesInStorage[1].Path: 0,
+	}, nil)
+
+	cnfBackup := *config.InstanceConfig()
+	defer func() {
+		*config.InstanceConfig() = cnfBackup
+	}()
+	config.InstanceConfig().VacuumCnf = *config.BuildVacuum(config.WithCheckBackup(false))
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+		DbInterractor:      database,
+		Cnf:                &config.InstanceConfig().VacuumCnf,
+	}
+
+	err := handler.DeleteGarbageInBucket(bucket, msg)
+	assert.NoError(t, err)
+
+	labels := prometheus.Labels{"bucket": bucket, "operation": "DELETE_GARBAGE"}
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessProcessed.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
+
+	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "DELETE_GARBAGE", "stage": "list"}))
+	assert.EqualValues(t, 2, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "DELETE_GARBAGE", "stage": "delete"}))
+	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestSize, labels))
+}
+
+func TestDeletePrefixInBucketRecordsMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const bucket = "prefix-metrics-bucket"
+
+	msg := message.Delete2Message{
+		Prefix:  "trash",
+		Garbage: true,
+		Confirm: true,
+	}
+
+	// "other/x" does not contain "trash" and must be skipped (counted as kept)
+	// before any delete attempt, unlike "trash/a" and "trash/b" which get deleted.
+	filesInStorage := []*object.ObjectInfo{
+		{Path: "trash/a"},
+		{Path: "trash/b"},
+		{Path: "other/x"},
+	}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().ListBucketPath(bucket, msg.Prefix, true).Return(filesInStorage, nil)
+	storage.EXPECT().ListFailedMultipartUploads(bucket).Return(map[string]string{}, nil)
+	storage.EXPECT().DeleteObject(bucket, gomock.Any()).Return(nil).Times(2)
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+		Cnf:                &config.Vacuum{TrashDeleteWorkers: 2},
+	}
+
+	err := handler.DeletePrefixInBucket(bucket, msg)
+	assert.NoError(t, err)
+
+	labels := prometheus.Labels{"bucket": bucket, "operation": "DELETE_PREFIX"}
+	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessProcessed.With(labels)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
+
+	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "DELETE_PREFIX", "stage": "list"}))
+	assert.EqualValues(t, 2, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "DELETE_PREFIX", "stage": "delete"}))
+	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestSize, labels))
+}
+
+func TestDeletePrefixInBucketRecordsKeptAfterRetriesExhausted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const bucket = "prefix-metrics-retry-bucket"
+
+	msg := message.Delete2Message{
+		Prefix:  "trash",
+		Garbage: true,
+		Confirm: true,
+	}
+
+	filesInStorage := []*object.ObjectInfo{
+		{Path: "trash/a"},
+		{Path: "trash/b"},
+	}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().ListBucketPath(bucket, msg.Prefix, true).Return(filesInStorage, nil)
+	storage.EXPECT().ListFailedMultipartUploads(bucket).Return(map[string]string{}, nil)
+	storage.EXPECT().DeleteObject(bucket, gomock.Any()).DoAndReturn(func(_, key string) error {
+		if key == "trash/b" {
+			return errors.New("persistent delete failure")
+		}
+		return nil
+	}).Times(11)
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+		Cnf:                &config.Vacuum{TrashDeleteWorkers: 2},
+	}
+
+	err := handler.DeletePrefixInBucket(bucket, msg)
+	assert.Error(t, err)
+
+	labels := prometheus.Labels{"bucket": bucket, "operation": "DELETE_PREFIX"}
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
 }

--- a/pkg/proc/delete_handler_test.go
+++ b/pkg/proc/delete_handler_test.go
@@ -1,7 +1,9 @@
 package proc_test
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/yezzey-gp/yproxy/config"
 	"github.com/yezzey-gp/yproxy/pkg/message"
@@ -17,6 +20,7 @@ import (
 	mock "github.com/yezzey-gp/yproxy/pkg/mock"
 	"github.com/yezzey-gp/yproxy/pkg/object"
 	"github.com/yezzey-gp/yproxy/pkg/proc"
+	"github.com/yezzey-gp/yproxy/pkg/ylogger"
 	"go.uber.org/mock/gomock"
 )
 
@@ -538,10 +542,10 @@ func TestDeleteGarbageInBucketMovesObjectsWhenCrazyDropDisabled(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestHandleUntrashifyFileRecordsMetrics(t *testing.T) {
+func TestHandleUntrashifyFileDoesNotRecordDeleteMetrics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	const bucket = "untrashify-metrics-bucket"
+	const bucket = "untrashify-no-metrics-bucket"
 
 	msg := message.UntrashifyMessage{
 		Name:    "path",
@@ -567,22 +571,25 @@ func TestHandleUntrashifyFileRecordsMetrics(t *testing.T) {
 	err := handler.HandleUntrashifyFile(msg)
 	assert.NoError(t, err)
 
+	// HandleUntrashifyFile restores files, it does not delete them, so it
+	// must not report through the delete/garbage-collection metrics - none
+	// of these series should exist for this bucket+operation.
 	labels := prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY"}
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessProcessed.With(labels)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessProcessed.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
 
-	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY", "stage": "list"}))
-	assert.EqualValues(t, 2, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY", "stage": "delete"}))
-	assert.EqualValues(t, 1, histogramSampleCount(t, metrics.DeleteRequestSize, labels))
+	assert.EqualValues(t, 0, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY", "stage": "list"}))
+	assert.EqualValues(t, 0, histogramSampleCount(t, metrics.DeleteRequestLatency, prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY", "stage": "delete"}))
+	assert.EqualValues(t, 0, histogramSampleCount(t, metrics.DeleteRequestSize, labels))
 }
 
-func TestHandleUntrashifyFileRecordsKeptOnFailure(t *testing.T) {
+func TestHandleUntrashifyFileReturnsErrorWithoutRecordingMetrics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	const bucket = "untrashify-metrics-failure-bucket"
+	const bucket = "untrashify-no-metrics-failure-bucket"
 
 	msg := message.UntrashifyMessage{
 		Name:    "path",
@@ -608,10 +615,47 @@ func TestHandleUntrashifyFileRecordsKeptOnFailure(t *testing.T) {
 	assert.Error(t, err)
 
 	labels := prometheus.Labels{"bucket": bucket, "operation": "UNTRASHIFY"}
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessTotal.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessRemaining.With(labels)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessDeleted.With(labels)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.DeleteProcessKept.With(labels)))
+}
+
+func TestHandleUntrashifyFileLogsProgressEveryInterval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const bucket = "untrashify-progress-bucket"
+	const totalFiles = metrics.ProgressLogInterval*2 + 5
+
+	msg := message.UntrashifyMessage{
+		Name:    "path",
+		Segnum:  60,
+		Confirm: true,
+	}
+
+	filesInStorage := make([]*object.ObjectInfo, totalFiles)
+	for i := range filesInStorage {
+		filesInStorage[i] = &object.ObjectInfo{Path: fmt.Sprintf("trash/segments_005/seg60/basebackups_005/yezzey/file%d", i)}
+	}
+
+	storage := mock.NewMockStorageInteractor(ctrl)
+	storage.EXPECT().DefaultBucket().Return(bucket)
+	storage.EXPECT().ListPath(msg.Name, true, nil).Return(filesInStorage, nil)
+	storage.EXPECT().MoveObject(bucket, gomock.Any(), gomock.Any()).Return(nil).Times(totalFiles)
+
+	var logBuf bytes.Buffer
+	origLogger := ylogger.Zero
+	progressLogger := zerolog.New(&logBuf)
+	ylogger.Zero = &progressLogger
+	defer func() { ylogger.Zero = origLogger }()
+
+	handler := proc.BasicGarbageMgr{
+		StorageInterractor: storage,
+	}
+
+	err := handler.HandleUntrashifyFile(msg)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, strings.Count(logBuf.String(), "untrashify progress"))
 }
 
 func TestDeleteGarbageInBucketRecordsMetrics(t *testing.T) {


### PR DESCRIPTION
Here we add prometheus metrics to measure deletion progress. 

The main metrics are DeleteProcessTotal && DeleteProcessProcessed. They are operation-specific, reported after completed listing operation.

To measure we instrument each operation by specific prometheus object (from promauto space) and increment metrics on each completed operation. The same for the operation latency