### PR TITLE
return error in case of unsupported message in ProcConn

### DIFF
--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -850,10 +850,6 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 		if err := ProcessDeleteObsolete(msg, s, bs, ycl); err != nil {
 			return err
 		}
-	case message.MessageTypeCopyDone:
-		msg := message.CopyDoneMessage{}
-		msg.Decode(body)
-		return fmt.Errorf("%s is not expected here", tp.String())
 	default:
 		unsupErr := ycl.ReplyError(fmt.Errorf("wrong request type: %s", tp.String()), "message is unsupported in ProcConn")
 		ylogger.Zero.Error().Err(unsupErr).Msg("failed to send error reply")

--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -855,10 +855,9 @@ func ProcConn(s storage.StorageInteractor, bs storage.StorageInteractor, cr cryp
 		msg.Decode(body)
 		return fmt.Errorf("%s is not expected here", tp.String())
 	default:
-		if replyErr := ycl.ReplyError(fmt.Errorf("wrong request type: %s", tp.String()), "wrong request type"); replyErr != nil {
-			ylogger.Zero.Error().Err(replyErr).Msg("failed to send error reply")
-		}
-		return nil
+		unsupErr := ycl.ReplyError(fmt.Errorf("wrong request type: %s", tp.String()), "message is unsupported in ProcConn")
+		ylogger.Zero.Error().Err(unsupErr).Msg("failed to send error reply")
+		return unsupErr
 	}
 
 	return nil

--- a/pkg/proc/interaction_test.go
+++ b/pkg/proc/interaction_test.go
@@ -113,7 +113,7 @@ func TestProcConnUnknownMessageTypeRepliesErrorWithoutPanic(t *testing.T) {
 
 	errorMessage := message.ErrorMessage{}
 	require.NotPanics(t, func() { errorMessage.Decode(body) })
-	require.Equal(t, "wrong request type", errorMessage.Message)
+	require.Equal(t, "message is unsupported in ProcConn", errorMessage.Message)
 	require.Contains(t, errorMessage.Error, "wrong request type")
 }
 

--- a/pkg/proc/interaction_test.go
+++ b/pkg/proc/interaction_test.go
@@ -122,12 +122,18 @@ func TestProcConnCopyDoneRepliesErrorWithoutPanic(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		err := proc.ProcConn(nil, nil, nil, ycl, &config.Vacuum{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not expected here")
+		require.NoError(t, err)
 	})
 	require.True(t, ycl.closed)
 	require.Equal(t, message.MessageTypeCopyDone, ycl.OPType())
-	require.Empty(t, ycl.rw.Written())
+
+	body := decodeWrittenPacket(t, ycl.rw.Written())
+	require.Equal(t, message.MessageTypeError, message.MessageType(body[0]))
+
+	errorMessage := message.ErrorMessage{}
+	require.NotPanics(t, func() { errorMessage.Decode(body) })
+	require.Equal(t, "message is unsupported in ProcConn", errorMessage.Message)
+	require.Contains(t, errorMessage.Error, "wrong request type")
 }
 
 func testPacket(tp message.MessageType) []byte {


### PR DESCRIPTION
In some situations (for example we exit from PutExtended after error but still got unprocessed message in a queue) ProcConn could get message it does not expect to get.

It's better to abort the whole iteraction cycle here since the right messages processing workflow was broken.

So we return error to let caller know that ProcConn actually failed unexpectedly.